### PR TITLE
Release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: bash
 
+cache: apt
+
 before_install:
   - echo "deb http://us.archive.ubuntu.com/ubuntu vivid main universe" | sudo tee -a /etc/apt/sources.list 
   - sudo apt-get update -qq

--- a/createrepo_c.spec
+++ b/createrepo_c.spec
@@ -1,10 +1,5 @@
 ###############################################################################
 
-# rpmbuilder:github       Tojaj:createrepo_c
-# rpmbuilder:revision     44798401a5ad9e8f802c72a12b29537599558b9e
-
-###############################################################################
-
 %define _posixroot        /
 %define _root             /root
 %define _bin              /bin
@@ -49,13 +44,13 @@
 
 Summary:            Creates a common metadata repository
 Name:               createrepo_c
-Version:            0.9.0
+Version:            0.9.1
 Release:            0%{?dist}
 License:            GPLv2
 Group:              Development/Tools
 URL:                https://github.com/Tojaj/createrepo_c
 
-Source0:            %{name}-%{version}.tar.bz2
+Source0:            https://github.com/rpm-software-management/%{name}/archive/%{version}.tar.gz
 
 BuildRoot:          %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
@@ -175,6 +170,9 @@ cmake -DCMAKE_INSTALL_PREFIX:PATH=%{_prefix} \
 ###############################################################################
 
 %changelog
+* Sat Nov 21 2015 Anton Novojilov <andy@essentialkaos.com> - 0.9.1-0
+- Updated to 0.9.1
+
 * Wed Jul 01 2015 Anton Novojilov <andy@essentialkaos.com> - 0.9.0-0
 - Updated to 0.9.0
 

--- a/daemonize.spec
+++ b/daemonize.spec
@@ -2,7 +2,7 @@
 
 Summary:         Run a command as a Unix daemon
 Name:            daemonize
-Version:         1.7.6
+Version:         1.7.7
 Release:         0%{?dist}
 Group:           Applications/System
 License:         BSD
@@ -69,6 +69,9 @@ rm -rf %{buildroot}
 ###############################################################################
 
 %changelog
+* Tue Dec 29 2015 Anton Novojilov <andy@essentialkaos.com> - 1.7.7-0
+- CFLAGS and LDFLAGS not passed through from configure to Makefile
+
 * Tue May 12 2015 Anton Novojilov <andy@essentialkaos.com> - 1.7.6-0
 - Fixed potential memory allocation issues
 

--- a/ejabberd/ejabberd.spec
+++ b/ejabberd/ejabberd.spec
@@ -51,8 +51,8 @@
 
 Summary:           Rock Solid, Massively Scalable, Infinitely Extensible XMPP Server
 Name:              ejabberd
-Version:           15.09
-Release:           1%{?dist}
+Version:           15.11
+Release:           0%{?dist}
 Group:             Development/Tools
 License:           GNU GPL v2
 URL:               https://www.ejabberd.im
@@ -155,12 +155,15 @@ getent passwd %{user_name} >/dev/null || %{__useradd} -d %{_sharedstatedir}/%{na
 %attr(755, -, -) %{_sbindir}/%{name}ctl
 %attr(644, -, -) %{_sysconfdir}/%{name}/*
 %{_initddir}/%{name}
-%{_libdir}/%{name}/*
+%{_libdir}/*
 %{_docdir}/%{name}/COPYING
 
 ###############################################################################
 
 %changelog
+* Sat Nov 21 2015 Anton Novojilov <andy@essentialkaos.com> - 15.11-0
+- Updated to 15.11
+
 * Wed Nov 18 2015 Anton Novojilov <andy@essentialkaos.com> - 15.09-1
 - Fixed minor bug in init script
 

--- a/erlang-R18/erlangR18.spec
+++ b/erlang-R18/erlangR18.spec
@@ -1186,12 +1186,12 @@ rm -rf %{buildroot}
 * Tue Dec 29 2015 Anton Novojilov <andy@essentialkaos.com> - 18.2.1-0
 - Updated to latest stable release
 
-* Thu Oct 01 2015 Anton Novojilov <andy@essentialkaos.com> - 18.1-0-0
+* Thu Oct 01 2015 Anton Novojilov <andy@essentialkaos.com> - 18.1-0
 - Updated to latest stable release
 
-* Mon Jul 20 2015 Anton Novojilov <andy@essentialkaos.com> - 18-0-1
+* Mon Jul 20 2015 Anton Novojilov <andy@essentialkaos.com> - 18-0
 - Fixed bug with crypto module
 - Fixed wrong dependencies in stack package
 
-* Sat Jul 18 2015 Anton Novojilov <andy@essentialkaos.com> - 18-0-0
+* Sat Jul 18 2015 Anton Novojilov <andy@essentialkaos.com> - 18-0
 - Initial build

--- a/erlang-R18/erlangR18.spec
+++ b/erlang-R18/erlangR18.spec
@@ -39,7 +39,7 @@
 %define elibdir           %{_libdir}/erlang/lib
 %define eprefix           %{_prefix}%{_lib32}
 %define ver_maj           18
-%define ver_min           1
+%define ver_min           2.1
 %define realname          erlang
 
 ###############################################################################
@@ -47,7 +47,7 @@
 Summary:           General-purpose programming language and runtime environment
 Name:              %{realname}%{ver_maj}
 Version:           %{ver_min}
-Release:           1%{?dist}
+Release:           0%{?dist}
 Group:             Development/Tools
 License:           MPL
 URL:               http://www.erlang.org
@@ -1183,6 +1183,9 @@ rm -rf %{buildroot}
 ###############################################################################
 
 %changelog
+* Tue Dec 29 2015 Anton Novojilov <andy@essentialkaos.com> - 18.2.1-0
+- Updated to latest stable release
+
 * Thu Oct 01 2015 Anton Novojilov <andy@essentialkaos.com> - 18.1-0-0
 - Updated to latest stable release
 

--- a/ffmpeg-kaos.spec
+++ b/ffmpeg-kaos.spec
@@ -34,7 +34,7 @@
 
 Summary:           Hyper fast MPEG1/MPEG4/H263/RV and AC3/MPEG audio encoder
 Name:              %{source_name}-kaos
-Version:           2.8
+Version:           2.8.2
 Release:           0%{?dist}
 License:           GPLv3
 Group:             System Environment/Libraries
@@ -152,6 +152,9 @@ test -f version.h || echo "#define FFMPEG_VERSION \"%{version}-%{release}\"" > v
 ###############################################################################
 
 %changelog
+* Sat Nov 21 2015 Anton Novojilov <andy@essentialkaos.com> - 2.8.2-0
+- Updated to version 2.8.2
+
 * Thu Oct 01 2015 Anton Novojilov <andy@essentialkaos.com> - 2.8-0
 - Updated to version 2.8
 

--- a/ffmpeg-kaos.spec
+++ b/ffmpeg-kaos.spec
@@ -34,7 +34,7 @@
 
 Summary:           Hyper fast MPEG1/MPEG4/H263/RV and AC3/MPEG audio encoder
 Name:              %{source_name}-kaos
-Version:           2.8.2
+Version:           2.8.4
 Release:           0%{?dist}
 License:           GPLv3
 Group:             System Environment/Libraries
@@ -152,6 +152,9 @@ test -f version.h || echo "#define FFMPEG_VERSION \"%{version}-%{release}\"" > v
 ###############################################################################
 
 %changelog
+* Tue Dec 29 2015 Anton Novojilov <andy@essentialkaos.com> - 2.8.4-0
+- Updated to version 2.8.4
+
 * Sat Nov 21 2015 Anton Novojilov <andy@essentialkaos.com> - 2.8.2-0
 - Updated to version 2.8.2
 

--- a/geos/geos.spec
+++ b/geos/geos.spec
@@ -35,15 +35,13 @@
 
 Summary:           GEOS is a C++ port of the Java Topology Suite
 Name:              geos
-Version:           3.4.2
+Version:           3.5.0
 Release:           0%{?dist}
 License:           LGPLv2
 Group:             Applications/Engineering
 URL:               http://trac.osgeo.org/geos
 
 Source0:           http://download.osgeo.org/%{name}/%{name}-%{version}.tar.bz2
-
-Patch0:            %{name}-gcc43.patch
 
 BuildRoot:         %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
@@ -90,8 +88,6 @@ Python module to build applications using GEOS and python
 %prep
 %setup -q
 
-%patch0 -p0 -b .gcc43
-
 %build
 
 # fix python path on 64bit
@@ -121,9 +117,11 @@ rm -rf %{buildroot}
 %clean
 rm -rf %{buildroot}
 
-%post -p /sbin/ldconfig
+%post
+/sbin/ldconfig
 
-%postun -p /sbin/ldconfig
+%postun
+/sbin/ldconfig
 
 ########################################################################################
 
@@ -157,5 +155,8 @@ rm -rf %{buildroot}
 ########################################################################################
 
 %changelog
+* Sat Nov 21 2015 Anton Novojilov <andy@essentialkaos.com> - 3.5.0-0
+- Updated to 3.5.0
+
 * Sat Sep 06 2014 Anton Novojilov <andy@essentialkaos.com> - 3.4.2-0
 - Initial build

--- a/git.spec
+++ b/git.spec
@@ -2,7 +2,7 @@
 
 Summary:          Core git tools
 Name:             git
-Version:          2.6.1
+Version:          2.6.3
 Release:          0%{?dist}
 License:          GPL
 Group:            Development/Tools
@@ -272,6 +272,9 @@ rm -rf %{buildroot}
 ###############################################################################
 
 %changelog
+* Sat Nov 21 2015 Anton Novojilov <andy@essentialkaos.com> - 2.6.3-0
+- Updated to latest release
+
 * Thu Oct 08 2015 Anton Novojilov <andy@essentialkaos.com> - 2.6.1-0
 - Updated to latest release
 

--- a/git.spec
+++ b/git.spec
@@ -2,7 +2,7 @@
 
 Summary:          Core git tools
 Name:             git
-Version:          2.6.3
+Version:          2.6.4
 Release:          0%{?dist}
 License:          GPL
 Group:            Development/Tools
@@ -272,6 +272,9 @@ rm -rf %{buildroot}
 ###############################################################################
 
 %changelog
+* Tue Dec 29 2015 Anton Novojilov <andy@essentialkaos.com> - 2.6.4-0
+- Updated to latest release
+
 * Sat Nov 21 2015 Anton Novojilov <andy@essentialkaos.com> - 2.6.3-0
 - Updated to latest release
 

--- a/goaccess.spec
+++ b/goaccess.spec
@@ -2,7 +2,7 @@
 
 Summary:         Real-time web log analyzer and interactive viewer
 Name:            goaccess
-Version:         0.9.6
+Version:         0.9.7
 Release:         0%{?dist}
 Group:           Development/Tools
 License:         GPLv2+
@@ -54,6 +54,13 @@ rm -rf %{buildroot}
 ########################################################################################
 
 %changelog
+* Tue Dec 29 2015 Anton Novojilov <andy@essentialkaos.com> - 0.9.7-0
+- Added Squid native log format to the config file
+- Fixed int overflow when getting total bandwidth using the on-disk storage
+- Fixed issue where a timestamp was stored as date under the visitors panel
+- Fixed issue where config dialog fields were not cleared out on select
+- Fixed issue where "Virtual Hosts" menu item wasn't shown in the HTML sidebar
+
 * Tue Oct 27 2015 Anton Novojilov <andy@essentialkaos.com> - 0.9.6-0
 - Fixed segfault when appending data to a log (follow) without virtualhosts.
 - Added command line option `--dcf` to view the default config file path.

--- a/golang/golang.spec
+++ b/golang/golang.spec
@@ -60,8 +60,8 @@
 
 Summary:           The Go Programming Language
 Name:              golang
-Version:           1.5.1
-Release:           1%{?dist}
+Version:           1.5.2
+Release:           0%{?dist}
 License:           BSD
 Group:             Development/Languages
 URL:               http://golang.org
@@ -709,6 +709,9 @@ touch -r %{goroot}/pkg/linux_arm/runtime.a %{goroot}/pkg/linux_arm/runtime/cgo.a
 ########################################################################################
 
 %changelog
+* Fri Dec 04 2015 Anton Novojilov <andy@essentialkaos.com> - 1.5.2-0
+- Updated to latest stable release
+
 * Sat Nov 21 2015 Anton Novojilov <andy@essentialkaos.com> - 1.5.1-1
 - Added git to dependencies
 

--- a/golang/golang.spec
+++ b/golang/golang.spec
@@ -61,7 +61,7 @@
 Summary:           The Go Programming Language
 Name:              golang
 Version:           1.5.1
-Release:           0%{?dist}
+Release:           1%{?dist}
 License:           BSD
 Group:             Development/Languages
 URL:               http://golang.org
@@ -76,6 +76,7 @@ BuildRoot:         %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n
 
 BuildRequires:     golang >= 1.4.2
 
+Requires:          git
 Requires:          %{name}-bin
 Requires:          %{name}-src = %{version}-%{release}
 
@@ -708,6 +709,9 @@ touch -r %{goroot}/pkg/linux_arm/runtime.a %{goroot}/pkg/linux_arm/runtime/cgo.a
 ########################################################################################
 
 %changelog
+* Sat Nov 21 2015 Anton Novojilov <andy@essentialkaos.com> - 1.5.1-1
+- Added git to dependencies
+
 * Thu Oct 22 2015 Anton Novojilov <andy@essentialkaos.com> - 1.5.1-0
 - Updated to latest stable release
 

--- a/h2o/h2o.spec
+++ b/h2o/h2o.spec
@@ -46,7 +46,7 @@
 
 Summary:              Very fast HTTP server written in C
 Name:                 h2o
-Version:              1.5.0
+Version:              1.5.4
 Release:              0%{?dist}
 License:              Copyright (c) 2014 DeNA Co., Ltd.
 Group:                System Environment/Daemons
@@ -172,182 +172,35 @@ fi
 ###############################################################################
 
 %changelog
-* Thu Oct 01 2015 Anton Novojilov <andy@essentialkaos.com> - 
-- [http2] enable http2-reprioritize-blocking-assets by 
-  default #528 (Kazuho Oku)
-- [ssl] fix issues with neverbleed #520 (Kazuho Oku)
-- [mruby] provide env- ['rack.errors'], env- ['SERVER_SOFTWARE'] #517 #519
-  (Masayoshi Takahashi, Kazuho Oku)
-- [ssl] add support for neverbleed - the OpenSSL / LibreSSL privilege
-  separation engine #520 (Kazuho Oku)
-- [http2] fix crash when http2-reprioritize-blocking-assets,
-  file.custom-handler are used together #511 #514 (Kazuho Oku)
-- [serurity fix]- [file] fix directory traversal (CVE-2015-5638) (Kazuho Oku)
-- [mruby] fix build failure when oniguruma is already installed #501 #506
-  (Kazuho Oku)
-- [mruby] update sample mruby app to use rack-based API #498 (Masayoshi 
-  Takahashi)
-- [core] introduce is_compressible and priority attributes to MIME
-  map #436 #496 (Kazuho Oku)
-- [access-log] fix bug that emitted unnecessary NUL char in certain
-  conditions #462 #463 (Kazuho Oku)
-- [fastcgi] support for http2 server-push using link: rel=preload
-  header #446 (Kazuho Oku)
-- [file] send etag and vary headers on 304 response #439 (Kazuho Oku)
-- [file] sort directory listing #412 #474 (Kazuho Oku)
-- [gzip] introduce support for on-the-fly gzip #413 #457 (Justin Zhu)
-- [http2] introduce cookie-based implementation of cache-aware
-  server-push #421 #432 (Kazuho Oku)
-- [http2] improve HPACK compression ratio of server-push #450 (Kazuho Oku)
-- [http2] never push if client requested not to #464 (Kazuho Oku)
-- [http2] send content-length if possible #472 (Kazuho Oku)
-- [mruby] production-level support using Rack-based
-  interface #467 #475 #489 (Kazuho Oku)
-- [reproxy] support delegation using relative URL #468 (Kazuho Oku)
-- [reproxy] preserve method if status is 307 or 308 #491 (Kazuho Oku)
-- [ssl] improved error handling of openssl ocsp 
-  command #449 #454 (Tatsuhiro Tsujikawa)
-- [ssl] use libressl on ARM as well #485 (Kazuho Oku)
+* Sat Nov 21 2015 Anton Novojilov <andy@essentialkaos.com> - 1.5.4-0
+- Updated to 1.5.4
+
+* Thu Oct 01 2015 Anton Novojilov <andy@essentialkaos.com> - 1.5.0-0
+- Updated to 1.5.0
 
 * Fri Sep 04 2015 Anton Novojilov <andy@essentialkaos.com> - 1.4.4-0
-- [misc] fix install error of libh2o-evloop in case development files of 
-  OpenSSL cannot be found #443 (Kazuho Oku)
-- [fastcgi] change ownership of domain socket when `fastcgi.spawn` command 
-  is used #433 (Masaki TAGAWA)
-- [fastcgi] kill fastcgi processes spawned by `fastcgi.spawn` command when 
-  standalone server receives SIGINT #444 (Kazuho Oku)
-- [file] fix file descriptor leak on multi-range request #434 (Justin Zhu)
-- [ssl] update libressl to 2.2.2 #440 (Kazuho Oku)
-- [misc] fix build error in case development files of OpenSSL cannot 
-  be found #433 (Kazuho Oku)
+- Updated to 1.4.4
 
 * Tue Aug 11 2015 Anton Novojilov <andy@essentialkaos.com> - 1.4.2-1
 - Some fixes in spec and init script
 
 * Mon Aug 10 2015 Anton Novojilov <andy@essentialkaos.com> - 1.4.2-0
-- [fastcgi] do not concatenate the headers (ex. Set-Cookie) sent by a 
-  FastCGI app #427 (Kazuho Oku)
-- [ssl] for guarding session ticket secret use writer-preferred locks on 
-  Linux as well #423 (Kazuho Oku)
-- [misc] suppress compiler warnings #415 (Syohei YOSHIDA)
+- Updated to 1.4.2
 
 * Wed Jul 01 2015 Anton Novojilov <andy@essentialkaos.com> - 1.3.1-0
-- [core] do not refuse to start-up when failing to enable TCP Fast Open 
-  #368 (Kazuho Oku)
-- [fastcgi] fix server start-up issues when using fastcgi.spawn #367 
-  (Kazuho Oku)
-- [SSL] support OCSP stapling using openssl ocsp command built from 
-  LibreSSL in addition to OpenSSL #366 (Tatsuhiro Tsujikawa)
-- [core] enable TCP fast-open #356 (Tatsuhiko Kubo)
-- [core] improve virtual-host lookup logic #293 #296 (Kazuho Oku)
-- [core] fix content being mis-sent for HEAD requests #300 #302 (Kazuho Oku)
-- [doc] bundle documents #292 (Kazuho Oku)
-- [fastcgi] add FastCGI support #346 #359 #360 #364 (Kazuho Oku)
-- [file] support for If-Range requests #345 (Justin Zhu)
-- [file] send 503 (not 403) in case if too many files are open #304 (Kazuho Oku)
-- [http2] add http2-reprioritize-blocking-assets directive to optimize 
-  first-paint time on Chrome #349 (Kazuho Oku)
-- [http2] fix incompliant behavior when the number of stream exceeds the 
-  negotiated maximum #341 #352 (Kazuho Oku)
-- [proxy] fix potential use-after-free issue in case upstream name is resolved 
-  using getaddrinfo #307 (Kazuho Oku)
-- [proxy] increase default I/O timeout from 5 to 30 seconds fb5c016 (Kazuho Oku)
-- [redirect] support internal redirect #364 (Kazuho Oku)
-- [SSL] fix assertion failure during handshake #316 (Kazuho Oku)
-- [SSL] fix assertion failure when receiving a corrupt TLS record 
-  (http2 only) #297 (Kazuho Oku)
-- [SSL] fix build error on OpenSUSE using libressl #337 (Kazuho Oku)
-- [SSL] select ALPN protocol based on server-side preference #335 (Justin Zhu)
-- [libh2o] build shared libraries as well #324 (pyos)
-- [libh2o] build libh2o-evloop #327 (Laurentiu Nicola)
-- [misc] emit stacktrace in case of fatal error (Linux only) #331 (Kazuho Oku)
-- [misc] improve NetBSD compatibility #289 (Kazuho Oku)
-- [misc] fix file descriptor leaks #336 (Kazuho Oku)
+- Updated to 1.3.1
 
 * Wed Apr 15 2015 Anton Novojilov <andy@essentialkaos.com> - 1.2.0-0
-- [core] bundle libyaml #248 (Kazuho Oku)
-- [core] implement master-worker process mode and daemon mode 
-  (bundles Server::Starter) #258 #270 (Kazuho Oku)
-- [file] more mime-types by default #250 #254 #280 (Tatsuhiko Kubo, 
-    George Liu, Kazuho Oku)
-- [file][http1] fix connection being closed if the length of content 
-  is zero #276 (Kazuho Oku)
-- [headers] fix heap overrun during configuration #251 (Kazuho Oku)
-- [http2] do not delay sending PUSH_PROMISE #221 (Kazuho Oku)
-- [http2] reduce memory footprint under high load #271 (Kazuho Oku)
-- [http2] fix incorrect error sent when number of streams exceed the 
-  limit #268 (Kazuho Oku)
-- [proxy] fix heap overrun when building request sent to upstream 
-  #266 #269 (Moto Ishizawa, Kazuho Oku)
-- [proxy] fix laggy response in case the length of content is zero 
-  #274 #276 (Kazuho Oku)
-- [SSL] fix potential stall while reading data from client #268 (Kazuho Oku)
-- [SSL] bundle LibreSSL #236 #272 (Kazuho Oku)
-- [SSL] obtain source-level compatibility with BoringSSL #228 (Kazuho Oku)
-- [SSL] add directive listen.ssl.cipher-preference for controlling 
-  the selection logic of cipher-suites #233 (Kazuho Oku)
-- [SSL] disable TLS compression #252 (bisho)
-- [libh2o] fix C++ compatibility (do not use empty struct) #225 (Kazuho Oku)
-- [libh2o] search external dependencies using pkg-config #227 (Kazuho Oku)
-- [misc] fix GCC version detection bug used for controlling compiler 
-  warnings #224 (Kazuho Oku)
-- [misc] check merory allocation failures in socket pool #265 (Tatsuhiko Kubo)
+- Updated to 1.2.0
 
 * Tue Mar 03 2015 Anton Novojilov <andy@essentialkaos.com> - 1.0.1-0
-- [core] change backlog size from 65,536 to 65,535 #183 (Tatsuhiko Kubo)
-- [http2] fix assertion failure in HPACK encoder #186 (Kazuho Oku)
-- [http2] add extern to some global variables that were not marked as 
-  such #178 (Kazuho Oku)
-- [proxy] close persistent upstream connection if client abruptly closes 
-  the stream #188 (Kazuho Oku)
-- [proxy] fix internal state corruption in case upstream sends response 
-  headers divided into multiple packets #189 (Kazuho Oku)
-- [SSL] add host header to OCSP request #176 (Masaaki Hirose)
-- [libh2o] do not require header files under deps/ when using 
-  libh2o #173 (Kazuho Oku)
-- [libh2o] fix compile error in examples when compiled with 
-  H2O_USE_LIBUV=0 #177 (Kazuho Oku)
-- [libh2o] in example, add missing / after the reference 
-  path #180 (Matthieu Garrigues)
-- [misc] fix invalid HTML in sample page #175 (Deepak Prakash)
+- Updated to 1.0.1
 
 * Tue Mar 03 2015 Anton Novojilov <andy@essentialkaos.com> - 1.0.0-0
-- [core] add redirect handler #150 (Kazuho Oku)
-- [core] add pid-file directive for specifying the pid file #164 (Kazuho Oku)
-- [core] connections accepted by host-specific listeners should not be handled 
-  by handlers of other hosts #163 (Kazuho Oku)
-- [core] (FreeBSD) fix a bug that prevented the standalone server from booting 
-  when run as root #160 (Kazuho Oku)
-- [core] switch to pipe-based interthread messaging #154 (Kazuho Oku)
-- [core] use kqueue on all BSDs #156 (Kazuho Oku)
-- [access-log] more logging directives #158 (Kazuho Oku)
-- [access-log] bugfix: header values were not logged when specified using 
-  uppercase letters #157 (Kazuho Oku)
-- [file] add application/json to defalt MIME-types #159 (Tatsuhiko Kubo)
-- [http2] add support for the finalized version of HTTP/2 #166 (Kazuho Oku)
-- [http2] fix issues reported by h2spec v0.0.6 #165 (Kazuho Oku)
-- [proxy] merge the cookie headers before sending to upstream #161 (Kazuho Oku)
-- [proxy] simplify the configuration directives (and make persistent upstream 
-  connections as default) #162 (Kazuho Oku)
-- [SSL] add configuration directive to preload DH params #148 (Jeff Marrison)
-- [libh2o] separate versioning scheme using H2O_LIBRARY_VERSION_* #167 (Kazuho Oku)
+- Updated to 1.0.0
 
 * Tue Jan 27 2015 Anton Novojilov <andy@essentialkaos.com> - 0.9.1-0
-- added configuration directives: ssl/cipher-suite, ssl/ocsp-update-interval, 
-  ssl/ocsp-max-failures, expires, file.send-gzip
-- [http2] added support for draft-16 (draft-14 is also supported)
-- [http2] dependency-based prioritization
-- [http2] improved conformance to the specification
-- [SSL] OCSP stapling (automatically enabled by default)
-- [SSL] fix compile error with OpenSSL below version 1.0.1
-- [file] content negotiation (serving .gz files)
-- [expires] added support for Cache-Control: max-age
-- [libh2o] libh2o and the header files installed by make install
-- [libh2o] fix compile error when used from C++
-- automatically setuids to nobody when run as root and if user directive is not set
-- automatically raises RLIMIT_NOFILE
-- uses all CPU cores by default
-- now compiles on NetBSD and other BSD-based systems
+- Updated to 0.9.1
 
 * Mon Dec 29 2014 Anton Novojilov <andy@essentialkaos.com> - 0.9.0-0
 - Initial build

--- a/h2o/h2o.spec
+++ b/h2o/h2o.spec
@@ -46,7 +46,7 @@
 
 Summary:              Very fast HTTP server written in C
 Name:                 h2o
-Version:              1.5.4
+Version:              1.6.1
 Release:              0%{?dist}
 License:              Copyright (c) 2014 DeNA Co., Ltd.
 Group:                System Environment/Daemons
@@ -172,6 +172,9 @@ fi
 ###############################################################################
 
 %changelog
+* Tue Dec 29 2015 Anton Novojilov <andy@essentialkaos.com> - 1.6.1-0
+- Updated to 1.6.1
+
 * Sat Nov 21 2015 Anton Novojilov <andy@essentialkaos.com> - 1.5.4-0
 - Updated to 1.5.4
 

--- a/haproxy-1.5/haproxy.spec
+++ b/haproxy-1.5/haproxy.spec
@@ -53,8 +53,8 @@
 
 Name:              haproxy
 Summary:           TCP/HTTP reverse proxy for high availability environments
-Version:           1.5.14
-Release:           1%{?dist}
+Version:           1.5.15
+Release:           0%{?dist}
 License:           GPLv2+
 URL:               http://haproxy.1wt.eu
 Group:             System Environment/Daemons
@@ -177,6 +177,40 @@ fi
 ###############################################################################
 
 %changelog
+* Sat Nov 21 2015 Anton Novojilov <andy@essentialkaos.com> - 1.5.15-0
+- BUG/MINOR: log: missing some ARGC_* entries in fmt_directives()
+- DOC: usesrc root privileges requirements
+- BUILD: ssl: Allow building against libssl without SSLv3.
+- DOC/MINOR: fix OpenBSD versions where haproxy works
+- BUG/MINOR: http/sample: gmtime/localtime can fail
+- DOC: typo in 'redirect', 302 code meaning
+- DOC: mention that ms is left-padded with zeroes.
+- CLEANUP: .gitignore: ignore more test files
+- CLEANUP: .gitignore: finally ignore everything but what is known.
+- MEDIUM: config: emit a warning on a frontend without listener
+- BUG/MEDIUM: counters: ensure that src_{inc,clr}_gpc0 creates a missing entry
+- DOC: ssl: missing LF
+- DOC: fix example of http-request using ssl_fc_session_id
+- BUG/MINOR: http: remove stupid HTTP_METH_NONE entry
+- BUG/MAJOR: http: don't call http_send_name_header() after an error
+- BUG/MINOR: tools: make str2sa_range() report unresolvable addresses
+- BUG/MEDIUM: acl: always accept match "found"
+- DOC: clarify how to make use of abstract sockets in socat
+- CLEANUP: config: make the errorloc/errorfile messages less confusing
+- BUG/MINOR: config: check that tune.bufsize is always positive
+- BUG/MEDIUM: proxy: ignore stopped peers
+- BUG/MEDIUM: proxy: do not wake stopped proxies' tasks during soft_stop()
+- BUG/MINOR: http: Add OPTIONS in supported http methods (found by find_http_meth)
+- BUILD: enable build on Linux/s390x
+- DOC: backend section missing parameters
+- DOC: stats paramaters available in frontend
+- BUG/MINOR: config: make the stats socket pass the correct proxy to the parsers
+- BUG/MEDIUM: pattern: fixup use_after_free in the pat_ref_delete_by_id
+- CLEANUP: don't ignore debian/ directory if present
+- FIX: small typo in an example using the "Referer" header
+- BUG/MEDIUM: config: count memory limits on 64 bits, not 32
+- DOC: add a CONTRIBUTING file
+
 * Mon Oct 26 2015 Anton Novojilov <andy@essentialkaos.com> - 1.5.14-1
 - Improved default config
 

--- a/haproxy-1.6/haproxy.spec
+++ b/haproxy-1.6/haproxy.spec
@@ -54,7 +54,7 @@
 
 Name:              haproxy
 Summary:           TCP/HTTP reverse proxy for high availability environments
-Version:           1.6.2
+Version:           1.6.3
 Release:           0%{?dist}
 License:           GPLv2+
 URL:               http://haproxy.1wt.eu
@@ -186,6 +186,56 @@ fi
 ###############################################################################
 
 %changelog
+* Tue Dec 29 2015 Anton Novojilov <andy@essentialkaos.com> - 1.6.3-0
+- BUG/MINOR: http rule: http capture 'id' rule points to a non existing i
+- BUG/MINOR: server: check return value of fgets() in apply_server_state(
+- BUG/MINOR: acl: don't use record layer in req_ssl_ve
+- BUILD: freebsd: double declaratio
+- BUG/MEDIUM: lua: clean output buffe
+- BUILD: check for libressl to be able to build against i
+- DOC: lua-api/index.rst small example fixes, spelling correction
+- DOC: lua: architecture and first step
+- DOC: relation between timeout http-request and option http-buffer-reques
+- BUILD: Make deviceatlas require PCR
+- BUG: http: do not abort keep-alive connections on server timeou
+- BUG/MEDIUM: http: switch the request channel to no-delay once done
+- BUG/MINOR: lua: don't force-sslv3 LUA's SSL socke
+- BUILD/MINOR: http: proto_http.h needs sample.
+- BUG/MEDIUM: http: don't enable auto-close on the response sid
+- BUG/MEDIUM: stream: fix half-closed timeout handlin
+- CLEANUP: compression: don't allocate DEFAULT_MAXZLIBMEM without USE_ZLI
+- BUG/MEDIUM: cli: changing compression rate-limiting must require admin leve
+- BUG/MEDIUM: sample: urlp can't match an empty valu
+- BUILD: dumpstats: silencing warning for printf format specifier / time_
+- CLEANUP: proxy: calloc call inverted argument
+- MINOR: da: silent logging by default and displaying DeviceAtlas support if built
+- BUG/MEDIUM: da: stop DeviceAtlas processing in the convertor if there is no input
+- DOC: Edited 51Degrees section of READM
+- BUG/MEDIUM: checks: email-alert not working when declared in default
+- BUG/MINOR: checks: email-alert causes a segfault when an unknown mailers section is configure
+- BUG/MINOR: checks: typo in an email-alert error messag
+- BUG/MINOR: tcpcheck: conf parsing error when no port configured on server and last rule is a CONNECT with no por
+- BUG/MINOR: tcpcheck: conf parsing error when no port configured on server and first rule(s) is (are) COMMEN
+- BUG/MEDIUM: http: fix http-reuse when frontend and backend diffe
+- DOC: prefer using http-request/response over reqXXX/rspXXX directive
+- BUG/MEDIUM: config: properly adjust maxconn with nbproc when memmax is force
+- BUG/MEDIUM: peers: table entries learned from a remote are pushed to others after a random delay
+- BUG/MEDIUM: peers: old stick table updates could be repushed
+- CLEANUP: haproxy: using _GNU_SOURCE instead of __USE_GNU macro
+- MINOR: lua: service/applet can have access to the HTTP headers when a POST is receive
+- REORG/MINOR: lua: convert boolean "int" to bitfiel
+- BUG/MEDIUM: lua: Lua applets must not fetch samples using http_tx
+- BUG/MINOR: lua: Lua applets must not use http_tx
+- BUG/MEDIUM: lua: Forbid HTTP applets from being called from tcp ruleset
+- BUG/MAJOR: lua: Do not force the HTTP analysers in use-service
+- CLEANUP: lua: bad error message
+- DOC: lua: fix lua AP
+- DOC: mailers: typo in 'hostname' descriptio
+- DOC: compression: missing mention of libslz for compression algorith
+- BUILD/MINOR: regex: missing heade
+- BUG/MINOR: stream: bad return cod
+- DOC: lua: fix somme errors and add implicit type
+
 * Sat Nov 21 2015 Anton Novojilov <andy@essentialkaos.com> - 1.6.2-0
 - BUILD: ssl: fix build error introduced in commit 7969a3 with OpenSSL < 1.0.0
 - DOC: fix a typo for a "deviceatlas" keyword

--- a/haproxy-1.6/haproxy.spec
+++ b/haproxy-1.6/haproxy.spec
@@ -54,7 +54,7 @@
 
 Name:              haproxy
 Summary:           TCP/HTTP reverse proxy for high availability environments
-Version:           1.6.0
+Version:           1.6.2
 Release:           0%{?dist}
 License:           GPLv2+
 URL:               http://haproxy.1wt.eu
@@ -180,12 +180,36 @@ fi
 %{_initrddir}/%{name}
 %{_sbindir}/%{name}
 %{_bindir}/halog
-%{_sbindir}/%{name}-systemd-wrapper
 %{_mandir}/man1/%{name}.1.gz
 %attr(0755, %{hp_user}, %{hp_group}) %dir %{hp_homedir}
 
 ###############################################################################
 
 %changelog
+* Sat Nov 21 2015 Anton Novojilov <andy@essentialkaos.com> - 1.6.2-0
+- BUILD: ssl: fix build error introduced in commit 7969a3 with OpenSSL < 1.0.0
+- DOC: fix a typo for a "deviceatlas" keyword
+- FIX: small typo in an example using the "Referer" header
+- BUG/MEDIUM: config: count memory limits on 64 bits, not 32
+- BUG/MAJOR: dns: first DNS response packet not matching queried hostname may lead to a loop
+- BUG/MINOR: dns: unable to parse CNAMEs response
+- BUG/MINOR: examples/haproxy.init: missing brace in quiet_check()
+- DOC: deviceatlas: more example use cases.
+- BUG/BUILD: replace haproxy-systemd-wrapper with $(EXTRA) in install-bin.
+- BUG/MAJOR: http: don't requeue an idle connection that is already queued
+- DOC: typo on capture.res.hdr and capture.req.hdr
+- BUG/MINOR: dns: check for duplicate nameserver id in a resolvers section was missing
+- CLEANUP: use direction names in place of numeric values
+- BUG/MEDIUM: lua: sample fetches based on response doesn't work
+
+* Sat Nov 21 2015 Anton Novojilov <andy@essentialkaos.com> - 1.6.1-0
+- DOC: specify that stats socket doc (section 9.2) is in management
+- BUILD: install only relevant and existing documentation
+- CLEANUP: don't ignore debian/ directory if present
+- BUG/MINOR: dns: parsing error of some DNS response
+- BUG/MEDIUM: namespaces: don't fail if no namespace is used
+- BUG/MAJOR: ssl: free the generated SSL_CTX if the LRU cache is disabled
+- MEDIUM: dns: Don't use the ANY query type
+
 * Thu Oct 15 2015 Anton Novojilov <andy@essentialkaos.com> - 1.6.0-0
 - Stable version 1.6

--- a/libmicrohttpd.spec
+++ b/libmicrohttpd.spec
@@ -33,7 +33,7 @@
 
 Summary:         Lightweight library for embedding a webserver in applications
 Name:            libmicrohttpd
-Version:         0.9.43
+Version:         0.9.46
 Release:         0%{?dist}
 License:         GNU LGPL
 Group:           Development/Libraries
@@ -191,6 +191,9 @@ fi
 ###############################################################################
 
 %changelog
+* Sat Nov 21 2015 Anton Novojilov <andy@essentialkaos.com> - 0.9.46-0
+- Updated to latest release
+
 * Thu Oct 01 2015 Anton Novojilov <andy@essentialkaos.com> - 0.9.43-0
 - Updated to latest release
 

--- a/memcached/memcached.spec
+++ b/memcached/memcached.spec
@@ -44,7 +44,7 @@
 
 Summary:                  High Performance, Distributed Memory Object Cache
 Name:                     memcached
-Version:                  1.4.24
+Version:                  1.4.25
 Release:                  0%{?dist}
 Group:                    System Environment/Daemons
 License:                  BSD
@@ -175,8 +175,11 @@ fi
 ###############################################################################
 
 %changelog
+* Sat Nov 21 2015 Anton Novojilov <andy@essentialkaos.com> - 1.4.25-0
+- Updated to latest release
+
 * Tue May 12 2015 Anton Novojilov <andy@essentialkaos.com> - 1.4.24-0
-- Updated to latest release 
+- Updated to latest release
 
 * Tue Jan 27 2015 Anton Novojilov <andy@essentialkaos.com> - 1.4.22-0
 - Updated to latest release
@@ -185,7 +188,7 @@ fi
 - Init script migrated to kaosv2
 
 * Wed Jun 04 2014 Anton Novojilov <andy@essentialkaos.com> - 1.4.20-1
-- Some minor fixes 
+- Some minor fixes
 
 * Wed Jun 04 2014 Anton Novojilov <andy@essentialkaos.com> - 1.4.20-0
 - Initial build

--- a/mercurial/mercurial.spec
+++ b/mercurial/mercurial.spec
@@ -11,7 +11,7 @@
 
 Summary:           Distributed source control management tool
 Name:              mercurial
-Version:           3.6.1
+Version:           3.6.2
 Release:           0%{?dist}
 License:           GPLv2+
 Group:             Development/Tools
@@ -166,6 +166,9 @@ rm -rf %{buildroot}
 ###############################################################################
 
 %changelog
+* Tue Dec 29 2015 Anton Novojilov <andy@essentialkaos.com> - 3.6.2-0
+- Updated to latest stable release
+
 * Sat Nov 21 2015 Anton Novojilov <andy@essentialkaos.com> - 3.6.1-0
 - Updated to latest stable release
 

--- a/mercurial/mercurial.spec
+++ b/mercurial/mercurial.spec
@@ -11,7 +11,7 @@
 
 Summary:           Distributed source control management tool
 Name:              mercurial
-Version:           3.5.1
+Version:           3.6.1
 Release:           0%{?dist}
 License:           GPLv2+
 Group:             Development/Tools
@@ -166,6 +166,9 @@ rm -rf %{buildroot}
 ###############################################################################
 
 %changelog
+* Sat Nov 21 2015 Anton Novojilov <andy@essentialkaos.com> - 3.6.1-0
+- Updated to latest stable release
+
 * Thu Oct 01 2015 Anton Novojilov <andy@essentialkaos.com> - 3.5.1-0
 - Updated to latest stable release
 

--- a/mmgeoip.spec
+++ b/mmgeoip.spec
@@ -19,7 +19,7 @@
 Summary:           MaxMinds data for GeoIP
 Name:              MMGeoIP
 Version:           1.2
-Release:           2%{?dist}
+Release:           3%{?dist}
 License:           Copyright © 2010 Achillefs Charmpilas
 Group:             Applications/Databases
 URL:               http://www.maxmind.com/
@@ -91,6 +91,9 @@ rm -rf %{buildroot}
 ########################################################################################
 
 %changelog
+* Tue Dec 29 2015 Anton Novojilov <andy@essentialkaos.com> - 1.2-3
+- Data updated
+
 * Thu Aug 06 2015 Anton Novojilov <andy@essentialkaos.com> - 1.2-2
 - Data updated
 

--- a/pgbouncer/pgbouncer.spec
+++ b/pgbouncer/pgbouncer.spec
@@ -47,7 +47,7 @@
 
 Summary:           Lightweight connection pooler for PostgreSQL
 Name:              pgbouncer
-Version:           1.6.1
+Version:           1.7
 Release:           0%{?dist}
 License:           MIT and BSD
 Group:             Applications/Databases
@@ -138,7 +138,7 @@ rm -rf %{buildroot}
 
 %files
 %defattr(-,root,root,-)
-%doc README NEWS AUTHORS
+%doc AUTHORS COPYRIGHT NEWS.rst NEWS.rst
 %config(noreplace) %{_sysconfdir}/%{name}/%{name}.ini
 %config(noreplace) %{_sysconfdir}/sysconfig/%{name}
 %config(noreplace) %{_sysconfdir}/logrotate.d/%{name}
@@ -152,6 +152,9 @@ rm -rf %{buildroot}
 ###############################################################################
 
 %changelog
+* Tue Dec 29 2015 Anton Novojilov <andy@essentialkaos.com> - 1.7-0
+- Updated to latest stable release
+
 * Fri Sep 04 2015 Anton Novojilov <andy@essentialkaos.com> - 1.6.1-0
 - Updated to latest stable release
 

--- a/pgcenter.spec
+++ b/pgcenter.spec
@@ -91,7 +91,7 @@ rm -rf %{buildroot}
 - Added iostat
 - Added nicstat
 - pg_stat_statements fixes
-- Use one key shortcut for config editing
+- One key shortcut for config editing
 - Other fixes and improvements
 
 * Wed Oct 21 2015 Anton Novojilov <andy@essentialkaos.com> - 0.1.3-0

--- a/pgcenter.spec
+++ b/pgcenter.spec
@@ -30,13 +30,13 @@
 
 Summary:            Top-like PostgreSQL statistics viewer
 Name:               pgcenter
-Version:            0.1.3
+Version:            0.2.0
 Release:            0%{?dist}
 License:            BSD 3-Clause
 Group:              Development/Tools
 URL:                https://github.com/lesovsky/pgcenter
 
-Source0:            https://github.com/lesovsky/%{name}/archive/v%{version}.tar.gz
+Source0:            https://github.com/lesovsky/%{name}/archive/%{version}.tar.gz
 
 BuildRoot:          %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
@@ -87,6 +87,13 @@ rm -rf %{buildroot}
 ###############################################################################
 
 %changelog
+* Sat Dec 19 2015 Anton Novojilov <andy@essentialkaos.com> - 0.2.0-0
+- Added iostat
+- Added nicstat
+- pg_stat_statements fixes
+- Use one key shortcut for config editing
+- Other fixes and improvements
+
 * Wed Oct 21 2015 Anton Novojilov <andy@essentialkaos.com> - 0.1.3-0
 - Added pg_stat_statements improvements
 - Added query detailed report based on pg_stat_statements

--- a/postgresql-92/postgis2.spec
+++ b/postgresql-92/postgis2.spec
@@ -39,7 +39,7 @@
 
 ########################################################################################
 
-%define maj_ver           2.1
+%define maj_ver           2.2
 %define pg_maj_ver        92
 %define pg_low_fullver    9.2.0
 %define pg_dir            %{_prefix}/pgsql-9.2
@@ -48,11 +48,13 @@
 %{!?utils:%define utils 1}
 %{!?raster:%define raster 1}
 
+%define _smp_mflags       -j1
+
 ########################################################################################
 
 Summary:           Geographic Information Systems Extensions to PostgreSQL 9.2
 Name:              %{realname}2_%{pg_maj_ver}
-Version:           2.1.8
+Version:           2.2.0
 Release:           0%{?dist}
 License:           GPLv2+
 Group:             Applications/Databases
@@ -65,14 +67,14 @@ Source2:           filter-requires-perl-Pg.sh
 BuildRoot:         %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires:     postgresql%{pg_maj_ver}-devel = %{pg_low_fullver}
-BuildRequires:     geos-devel >= 3.4.2 chrpath make gcc
+BuildRequires:     geos-devel >= 3.5 chrpath make gcc pcre-devel
 BuildRequires:     proj-devel libtool flex json-c-devel libxml2-devel
 
 %if %raster
 BuildRequires:     gdal-devel >= 1.8.0
 %endif
 
-Requires:          postgresql%{pg_maj_ver} geos >= 3.4.2 proj hdf5 json-c
+Requires:          postgresql%{pg_maj_ver} geos >= 3.5 proj hdf5 json-c
 Requires:          %{realname}-client = %{version}-%{release}
 
 Requires(post):    %{_sbindir}/update-alternatives
@@ -209,27 +211,27 @@ rm -rf %{buildroot}
 %files
 %defattr(-,root,root)
 %doc COPYING CREDITS NEWS TODO README.%{realname} doc/html loader/README.* doc/%{realname}.xml doc/ZMSgeoms.txt
+%{pg_dir}/share/contrib/%{realname}-%{maj_ver}/*legacy*.sql
 %{pg_dir}/share/contrib/%{realname}-%{maj_ver}/postgis.sql
 %{pg_dir}/share/contrib/%{realname}-%{maj_ver}/postgis_comments.sql
-%{pg_dir}/share/contrib/%{realname}-%{maj_ver}/postgis_upgrade*.sql
 %{pg_dir}/share/contrib/%{realname}-%{maj_ver}/postgis_restore.pl
-%{pg_dir}/share/contrib/%{realname}-%{maj_ver}/uninstall_postgis.sql
-%{pg_dir}/share/contrib/%{realname}-%{maj_ver}/*legacy*.sql
+%{pg_dir}/share/contrib/%{realname}-%{maj_ver}/postgis_upgrade*.sql
 %{pg_dir}/share/contrib/%{realname}-%{maj_ver}/raster_comments.sql
+%{pg_dir}/share/contrib/%{realname}-%{maj_ver}/sfcgal_comments.sql
 %{pg_dir}/share/contrib/%{realname}-%{maj_ver}/spatial*.sql
 %{pg_dir}/share/contrib/%{realname}-%{maj_ver}/topology*.sql
-%{pg_dir}/share/contrib/%{realname}-%{maj_ver}/uninstall_sfcgal.sql
-%{pg_dir}/share/contrib/%{realname}-%{maj_ver}/uninstall_topology.sql
-%{pg_dir}/share/extension/%{realname}-*.sql
-%{pg_dir}/share/extension/%{realname}.control
-%{pg_dir}/share/extension/%{realname}_topology-*.sql
-%{pg_dir}/share/extension/%{realname}_topology.control
-%{pg_dir}/share/extension/%{realname}_tiger_geocoder*.sql
-%{pg_dir}/share/extension/%{realname}_tiger_geocoder.control
+%{pg_dir}/share/contrib/%{realname}-%{maj_ver}/uninstall_postgis.sql
+%{pg_dir}/share/contrib/%{realname}_topology-%{maj_ver}/topology.sql
+%{pg_dir}/share/contrib/%{realname}_topology-%{maj_ver}/topology_upgrade.sql
+%{pg_dir}/share/contrib/%{realname}_topology-%{maj_ver}/uninstall_topology.sql
+%{pg_dir}/share/extension/%{realname}*
+%{pg_dir}/share/extension/address_standardizer*
 %attr(755,root,root) %{pg_dir}/lib/%{realname}-*.so
-%{pg_dir}/lib/liblwgeom*.so
+%{pg_dir}/lib/liblwgeom*.so*
 %if %raster
 %{pg_dir}/share/contrib/%{realname}-%{maj_ver}/*rtpostgis*.sql
+%{pg_dir}/lib/address_standardizer-%{maj_ver}.so
+%{pg_dir}/lib/postgis_topology-%{maj_ver}.so
 %{pg_dir}/lib/rtpostgis-%{maj_ver}.so
 %endif
 
@@ -240,6 +242,7 @@ rm -rf %{buildroot}
 %files devel
 %defattr(644,root,root)
 %{_includedir}/liblwgeom.h
+%{_includedir}/liblwgeom_topo.h
 %{pg_dir}/lib/liblwgeom*.a
 %{pg_dir}/lib/liblwgeom*.la
 
@@ -253,10 +256,14 @@ rm -rf %{buildroot}
 %files docs
 %defattr(-,root,root)
 %doc %{realname}-%{version}.pdf
+%{_defaultdocdir}/pgsql/extension/README.address_standardizer
 
 ########################################################################################
 
 %changelog
+* Sat Nov 21 2015 Anton Novojilov <andy@essentialkaos.com> - 2.2.0-0
+- Updated to latest stable release
+
 * Thu Aug 06 2015 Anton Novojilov <andy@essentialkaos.com> - 2.1.8-0
 - Updated to latest stable release
 

--- a/postgresql-93/postgis2.spec
+++ b/postgresql-93/postgis2.spec
@@ -39,7 +39,7 @@
 
 ########################################################################################
 
-%define maj_ver           2.1
+%define maj_ver           2.2
 %define pg_maj_ver        93
 %define pg_low_fullver    9.3.0
 %define pg_dir            %{_prefix}/pgsql-9.3
@@ -48,11 +48,13 @@
 %{!?utils:%define utils 1}
 %{!?raster:%define raster 1}
 
+%define _smp_mflags       -j1
+
 ########################################################################################
 
 Summary:           Geographic Information Systems Extensions to PostgreSQL 9.3
 Name:              %{realname}2_%{pg_maj_ver}
-Version:           2.1.8
+Version:           2.2.0
 Release:           0%{?dist}
 License:           GPLv2+
 Group:             Applications/Databases
@@ -65,14 +67,14 @@ Source2:           filter-requires-perl-Pg.sh
 BuildRoot:         %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires:     postgresql%{pg_maj_ver}-devel = %{pg_low_fullver}
-BuildRequires:     geos-devel >= 3.4.2 chrpath make gcc
+BuildRequires:     geos-devel >= 3.5 chrpath make gcc pcre-devel
 BuildRequires:     proj-devel libtool flex json-c-devel libxml2-devel
 
 %if %raster
 BuildRequires:     gdal-devel >= 1.8.0
 %endif
 
-Requires:          postgresql%{pg_maj_ver} geos >= 3.4.2 proj hdf5 json-c
+Requires:          postgresql%{pg_maj_ver} geos >= 3.5 proj hdf5 json-c
 Requires:          %{realname}-client = %{version}-%{release}
 
 Requires(post):    %{_sbindir}/update-alternatives
@@ -209,27 +211,27 @@ rm -rf %{buildroot}
 %files
 %defattr(-,root,root)
 %doc COPYING CREDITS NEWS TODO README.%{realname} doc/html loader/README.* doc/%{realname}.xml doc/ZMSgeoms.txt
+%{pg_dir}/share/contrib/%{realname}-%{maj_ver}/*legacy*.sql
 %{pg_dir}/share/contrib/%{realname}-%{maj_ver}/postgis.sql
 %{pg_dir}/share/contrib/%{realname}-%{maj_ver}/postgis_comments.sql
-%{pg_dir}/share/contrib/%{realname}-%{maj_ver}/postgis_upgrade*.sql
 %{pg_dir}/share/contrib/%{realname}-%{maj_ver}/postgis_restore.pl
-%{pg_dir}/share/contrib/%{realname}-%{maj_ver}/uninstall_postgis.sql
-%{pg_dir}/share/contrib/%{realname}-%{maj_ver}/*legacy*.sql
+%{pg_dir}/share/contrib/%{realname}-%{maj_ver}/postgis_upgrade*.sql
 %{pg_dir}/share/contrib/%{realname}-%{maj_ver}/raster_comments.sql
+%{pg_dir}/share/contrib/%{realname}-%{maj_ver}/sfcgal_comments.sql
 %{pg_dir}/share/contrib/%{realname}-%{maj_ver}/spatial*.sql
 %{pg_dir}/share/contrib/%{realname}-%{maj_ver}/topology*.sql
-%{pg_dir}/share/contrib/%{realname}-%{maj_ver}/uninstall_sfcgal.sql
-%{pg_dir}/share/contrib/%{realname}-%{maj_ver}/uninstall_topology.sql
-%{pg_dir}/share/extension/%{realname}-*.sql
-%{pg_dir}/share/extension/%{realname}.control
-%{pg_dir}/share/extension/%{realname}_topology-*.sql
-%{pg_dir}/share/extension/%{realname}_topology.control
-%{pg_dir}/share/extension/%{realname}_tiger_geocoder*.sql
-%{pg_dir}/share/extension/%{realname}_tiger_geocoder.control
+%{pg_dir}/share/contrib/%{realname}-%{maj_ver}/uninstall_postgis.sql
+%{pg_dir}/share/contrib/%{realname}_topology-%{maj_ver}/topology.sql
+%{pg_dir}/share/contrib/%{realname}_topology-%{maj_ver}/topology_upgrade.sql
+%{pg_dir}/share/contrib/%{realname}_topology-%{maj_ver}/uninstall_topology.sql
+%{pg_dir}/share/extension/%{realname}*
+%{pg_dir}/share/extension/address_standardizer*
 %attr(755,root,root) %{pg_dir}/lib/%{realname}-*.so
-%{pg_dir}/lib/liblwgeom*.so
+%{pg_dir}/lib/liblwgeom*.so*
 %if %raster
 %{pg_dir}/share/contrib/%{realname}-%{maj_ver}/*rtpostgis*.sql
+%{pg_dir}/lib/address_standardizer-%{maj_ver}.so
+%{pg_dir}/lib/postgis_topology-%{maj_ver}.so
 %{pg_dir}/lib/rtpostgis-%{maj_ver}.so
 %endif
 
@@ -240,6 +242,7 @@ rm -rf %{buildroot}
 %files devel
 %defattr(644,root,root)
 %{_includedir}/liblwgeom.h
+%{_includedir}/liblwgeom_topo.h
 %{pg_dir}/lib/liblwgeom*.a
 %{pg_dir}/lib/liblwgeom*.la
 
@@ -253,10 +256,14 @@ rm -rf %{buildroot}
 %files docs
 %defattr(-,root,root)
 %doc %{realname}-%{version}.pdf
+%{_defaultdocdir}/pgsql/extension/README.address_standardizer
 
 ########################################################################################
 
 %changelog
+* Sat Nov 21 2015 Anton Novojilov <andy@essentialkaos.com> - 2.2.0-0
+- Updated to latest stable release
+
 * Thu Aug 06 2015 Anton Novojilov <andy@essentialkaos.com> - 2.1.8-0
 - Updated to latest stable release
 

--- a/postgresql-94/postgis2.spec
+++ b/postgresql-94/postgis2.spec
@@ -39,7 +39,7 @@
 
 ########################################################################################
 
-%define maj_ver           2.1
+%define maj_ver           2.2
 %define pg_maj_ver        94
 %define pg_low_fullver    9.4.0
 %define pg_dir            %{_prefix}/pgsql-9.4
@@ -48,11 +48,13 @@
 %{!?utils:%define utils 1}
 %{!?raster:%define raster 1}
 
+%define _smp_mflags       -j1
+
 ########################################################################################
 
 Summary:           Geographic Information Systems Extensions to PostgreSQL 9.4
 Name:              %{realname}2_%{pg_maj_ver}
-Version:           2.1.8
+Version:           2.2.0
 Release:           0%{?dist}
 License:           GPLv2+
 Group:             Applications/Databases
@@ -65,14 +67,14 @@ Source2:           filter-requires-perl-Pg.sh
 BuildRoot:         %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires:     postgresql%{pg_maj_ver}-devel = %{pg_low_fullver}
-BuildRequires:     geos-devel >= 3.4.2 chrpath make gcc
+BuildRequires:     geos-devel >= 3.5 chrpath make gcc pcre-devel
 BuildRequires:     proj-devel libtool flex json-c-devel libxml2-devel
 
 %if %raster
 BuildRequires:     gdal-devel >= 1.8.0
 %endif
 
-Requires:          postgresql%{pg_maj_ver} geos >= 3.4.2 proj hdf5 json-c
+Requires:          postgresql%{pg_maj_ver} geos >= 3.5 proj hdf5 json-c
 Requires:          %{realname}-client = %{version}-%{release}
 
 Requires(post):    %{_sbindir}/update-alternatives
@@ -209,27 +211,27 @@ rm -rf %{buildroot}
 %files
 %defattr(-,root,root)
 %doc COPYING CREDITS NEWS TODO README.%{realname} doc/html loader/README.* doc/%{realname}.xml doc/ZMSgeoms.txt
+%{pg_dir}/share/contrib/%{realname}-%{maj_ver}/*legacy*.sql
 %{pg_dir}/share/contrib/%{realname}-%{maj_ver}/postgis.sql
 %{pg_dir}/share/contrib/%{realname}-%{maj_ver}/postgis_comments.sql
-%{pg_dir}/share/contrib/%{realname}-%{maj_ver}/postgis_upgrade*.sql
 %{pg_dir}/share/contrib/%{realname}-%{maj_ver}/postgis_restore.pl
-%{pg_dir}/share/contrib/%{realname}-%{maj_ver}/uninstall_postgis.sql
-%{pg_dir}/share/contrib/%{realname}-%{maj_ver}/*legacy*.sql
+%{pg_dir}/share/contrib/%{realname}-%{maj_ver}/postgis_upgrade*.sql
 %{pg_dir}/share/contrib/%{realname}-%{maj_ver}/raster_comments.sql
+%{pg_dir}/share/contrib/%{realname}-%{maj_ver}/sfcgal_comments.sql
 %{pg_dir}/share/contrib/%{realname}-%{maj_ver}/spatial*.sql
 %{pg_dir}/share/contrib/%{realname}-%{maj_ver}/topology*.sql
-%{pg_dir}/share/contrib/%{realname}-%{maj_ver}/uninstall_sfcgal.sql
-%{pg_dir}/share/contrib/%{realname}-%{maj_ver}/uninstall_topology.sql
-%{pg_dir}/share/extension/%{realname}-*.sql
-%{pg_dir}/share/extension/%{realname}.control
-%{pg_dir}/share/extension/%{realname}_topology-*.sql
-%{pg_dir}/share/extension/%{realname}_topology.control
-%{pg_dir}/share/extension/%{realname}_tiger_geocoder*.sql
-%{pg_dir}/share/extension/%{realname}_tiger_geocoder.control
+%{pg_dir}/share/contrib/%{realname}-%{maj_ver}/uninstall_postgis.sql
+%{pg_dir}/share/contrib/%{realname}_topology-%{maj_ver}/topology.sql
+%{pg_dir}/share/contrib/%{realname}_topology-%{maj_ver}/topology_upgrade.sql
+%{pg_dir}/share/contrib/%{realname}_topology-%{maj_ver}/uninstall_topology.sql
+%{pg_dir}/share/extension/%{realname}*
+%{pg_dir}/share/extension/address_standardizer*
 %attr(755,root,root) %{pg_dir}/lib/%{realname}-*.so
-%{pg_dir}/lib/liblwgeom*.so
+%{pg_dir}/lib/liblwgeom*.so*
 %if %raster
 %{pg_dir}/share/contrib/%{realname}-%{maj_ver}/*rtpostgis*.sql
+%{pg_dir}/lib/address_standardizer-%{maj_ver}.so
+%{pg_dir}/lib/postgis_topology-%{maj_ver}.so
 %{pg_dir}/lib/rtpostgis-%{maj_ver}.so
 %endif
 
@@ -240,6 +242,7 @@ rm -rf %{buildroot}
 %files devel
 %defattr(644,root,root)
 %{_includedir}/liblwgeom.h
+%{_includedir}/liblwgeom_topo.h
 %{pg_dir}/lib/liblwgeom*.a
 %{pg_dir}/lib/liblwgeom*.la
 
@@ -253,10 +256,14 @@ rm -rf %{buildroot}
 %files docs
 %defattr(-,root,root)
 %doc %{realname}-%{version}.pdf
+%{_defaultdocdir}/pgsql/extension/README.address_standardizer
 
 ########################################################################################
 
 %changelog
+* Sat Nov 21 2015 Anton Novojilov <andy@essentialkaos.com> - 2.2.0-0
+- Updated to latest stable release
+
 * Thu Aug 06 2015 Anton Novojilov <andy@essentialkaos.com> - 2.1.8-0
 - Updated to latest stable release
 

--- a/rabbitmq/rabbitmq-server.spec
+++ b/rabbitmq/rabbitmq-server.spec
@@ -46,13 +46,13 @@
 
 Summary:           The RabbitMQ server
 Name:              %{_basename}-server
-Version:           3.5.6
+Version:           3.6.0
 Release:           0%{?dist}
 License:           MPLv1.1
 Group:             Applications/Internet
 URL:               http://www.rabbitmq.com
 
-Source0:           http://www.rabbitmq.com/releases/%{name}/v%{version}/%{name}-%{version}.tar.gz
+Source0:           http://www.rabbitmq.com/releases/%{name}/v%{version}/%{name}-%{version}.tar.xz
 Source1:           %{name}.init
 Source2:           %{_basename}-script-wrapper
 Source3:           %{name}.logrotate
@@ -87,10 +87,10 @@ scalable implementation of an AMQP broker.
 %install
 %{__rm} -rf %{buildroot}
 
-%{__make} install TARGET_DIR=%{buildroot}%{_rabbit_erllibdir} \
-                  SBIN_DIR=%{buildroot}%{_rabbit_libdir}/bin \
-                  MAN_DIR=%{buildroot}%{_mandir} \
-                  DOC_INSTALL_DIR=%{buildroot}%{_sysconfdir}/%{_basename}
+%{__make} install-bin install-man DESTDIR=%{buildroot} \
+                                  PREFIX=%{_exec_prefix} \
+                                  RMQ_ROOTDIR=%{_rabbit_libdir} \
+                                  MANDIR=%{_mandir}
 
 %{__mkdir_p} %{buildroot}%{_localstatedir}/lib/%{_basename}/mnesia
 %{__mkdir_p} %{buildroot}%{_logdir}/%{_basename}
@@ -157,6 +157,9 @@ done
 ###############################################################################
 
 %changelog
+* Tue Dec 29 2015 Anton Novojilov <andy@essentialkaos.com> - 3.6.0-0
+- Updated to latest release
+
 * Sat Nov 21 2015 Anton Novojilov <andy@essentialkaos.com> - 3.5.6-0
 - Updated to latest release
 

--- a/rabbitmq/rabbitmq-server.spec
+++ b/rabbitmq/rabbitmq-server.spec
@@ -46,7 +46,7 @@
 
 Summary:           The RabbitMQ server
 Name:              %{_basename}-server
-Version:           3.5.5
+Version:           3.5.6
 Release:           0%{?dist}
 License:           MPLv1.1
 Group:             Applications/Internet
@@ -157,6 +157,9 @@ done
 ###############################################################################
 
 %changelog
+* Sat Nov 21 2015 Anton Novojilov <andy@essentialkaos.com> - 3.5.6-0
+- Updated to latest release
+
 * Thu Oct 01 2015 Anton Novojilov <andy@essentialkaos.com> - 3.5.5-0
 - Updated to latest release
 

--- a/redis/redis.spec
+++ b/redis/redis.spec
@@ -37,7 +37,7 @@
 
 Summary:            A persistent key-value database
 Name:               redis
-Version:            3.0.5
+Version:            3.0.6
 Release:            0%{?dist}
 License:            BSD
 Group:              Applications/Databases
@@ -189,6 +189,29 @@ fi
 ###############################################################################
 
 %changelog
+* Tue Dec 29 2015 Anton Novojilov <andy@essentialkaos.com> - 3.0.6-0
+- [FIX] lua_struct.c/getnum security issue fixed. (Luca Bruno discovered it,
+        patched by Sun He and Chris Lamb)
+- [FIX] Redis Cluster replica migration fixed. See issue 2924 for details.
+        (Salvatore Sanfilippo)
+- [FIX] Fix a race condition in processCommand() because of interactions
+        with freeMemoryIfNeeded(). Details in issue 2948 and especially
+        in the commit message d999f5a. (Race found analytically by
+        Oran Agra, patch by Salvatore Sanfilippo)
+
+- [NEW] Backported from the upcoming Redis 3.2:
+        MIGRATE now supports an extended multiple-keys pipelined mode, which
+        is an order of magnitude faster. Redis Cluster now uses this mode
+        in order to perform reshardings and rebalancings. (Salvatore Sanfilippo)
+- [NEW] Backported from the upcoming Redis 3.2:
+        Redis Cluster has now support for rebalancing via the redis-trib
+        rebalance command. Demo here:
+        https://asciinema.org/a/0tw2e5740kouda0yhkqrm5790
+        Official documentation will be available ASAP. (Salvatore Sanfilippo)
+- [NEW] Redis Cluster redis-trib.rb new "info" subcommand.
+- [NEW] Redis Cluster tests improved. (Salvatore Sanfilippo)
+- [NEW] Log offending memory access address on SIGSEGV/SIGBUS
+
 * Sat Oct 24 2015 Anton Novojilov <andy@essentialkaos.com> - 3.0.5-0
 - [FIX] MOVE now moves the TTL as well. A bug lasting forever... finally
         fixed thanks to Andy Grunwald that reported it.

--- a/snort/snort.spec
+++ b/snort/snort.spec
@@ -53,7 +53,7 @@
 
 Summary:         An open source Network Intrusion Detection System (NIDS)
 Name:            snort
-Version:         2.9.7.6
+Version:         2.9.8.0
 Release:         0%{?dist}
 License:         GPL
 Group:           Applications/Internet
@@ -212,6 +212,9 @@ fi
 ########################################################################################
 
 %changelog
+* Tue Dec 29 2015 Anton Novojilov <andy@essentialkaos.com> - 2.9.8.0-0
+- Updated to latest version
+
 * Thu Oct 01 2015 Anton Novojilov <andy@essentialkaos.com> - 2.9.7.6-0
 - Updated to latest version
 

--- a/tcpkali.spec
+++ b/tcpkali.spec
@@ -30,7 +30,7 @@
 
 Summary:            High performance TCP and WebSocket load generator and sink
 Name:               tcpkali
-Version:            0.6
+Version:            0.7
 Release:            0%{?dist}
 License:            BSD 2-Clause
 Group:              Development/Tools
@@ -75,10 +75,19 @@ autoreconf -iv
 %defattr(-,root,root,-)
 %doc LICENSE README.md TODO.md
 %{_bindir}/%{name}
+%{_mandir}/man1/%{name}.1*
 
 ###############################################################################
 
 %changelog
+* Tue Dec 29 2015 Anton Novojilov <andy@essentialkaos.com> - 0.7-0
+- Added a manual page. man tcpkali after installation.
+- Exceed 64k connections limit by using all available IP aliases on network interfaces.
+- --latency-marker-skip <N> to ignore the first occurrences of a marker.
+- --listen-mode=active to send data for connections received through -l.
+- --source-ip <IP> option to restrict or change source IPs.
+- "Bandwidth per channel:" output changed to ⇅ to reflect bi-direction.
+
 * Thu May 14 2015 Anton Novojilov <andy@essentialkaos.com> - 0.6-0
 - Parse \{connection.uid} type expressions in --first-message, --message, 
   --latency-marker parameters, allowing constructing payloads unique per 

--- a/tmux.spec
+++ b/tmux.spec
@@ -6,17 +6,17 @@
 
 Summary:              A terminal multiplexer
 Name:                 tmux
-Version:              2.0
+Version:              2.1
 Release:              0%{?dist}
 License:              ISC and BSD
 Group:                Applications/System
 URL:                  http://sourceforge.net/projects/tmux
 
-Source:               http://downloads.sourceforge.net/%{name}/%{name}-%{version}.tar.gz
+Source:               https://github.com/%{name}/%{name}/archive/%{version}.tar.gz
 
 BuildRoot:            %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
-BuildRequires:        ncurses-devel libevent-devel >= 1.4.14b
+BuildRequires:        ncurses-devel libevent2-devel
 
 ###############################################################################
 
@@ -29,10 +29,12 @@ as GNU Screen.
 ###############################################################################
 
 %prep
-%setup -q
+%setup -qn %{name}-%{version}
 
 %build
+./autogen.sh
 %configure
+
 %{__make}  %{?_smp_mflags} LDFLAGS="%{optflags}"
 
 %install
@@ -60,60 +62,17 @@ fi
 ###############################################################################
 
 %changelog
-* Tue May 12 2015 Anton Novojilov <andy@essentialkaos.com> - 2.0-0
-- The choose-list command has been removed.
-- 'terminal-overrides' is now a server option, not a session option.
-- 'message-limit' is now a server option, not a session option.
-- 'monitor-content' option has been removed.
-- 'pane_start_path' option has been removed.
-- The "info" mechanism which used to (for some commands) provide feedback
-  has been removed, and like other commands, they now produce nothing on
-  success.
-- tmux can now write an entry to utmp if the library 'utempter' is present
-  at compile time.
-- set-buffer learned append mode (-a), and a corresponding
-  'append-selection' command has been added to copy-mode.
-- choose-mode now has the following commands which can be bound:
-  - start-of-list
-  - end-of-list
-  - top-line
-  - bottom-line
-- choose-buffer now understands UTF-8.
-- Pane navigation has changed:
-  - The old way of always using the top or left if the choice is ambiguous.
-  - The new way of remembering the last used pane is annoying if the
-    layout is balanced and the leftmost is obvious to the user (because
-    clearly if we go right from the top-left in a tiled set of four we want
-    to end up in top-right, even if we were last using the bottom-right).
+* Sun Nov 22 2015 Anton Novojilov <andy@essentialkaos.com> - 2.1-0
+- Updated to 2.1
 
-      So instead, use a combination of both: if there is only one possible
-      pane alongside the current pane, move to it, otherwise choose the most
-      recently used of the choice.
-- 'set-buffer' can now be told to give names to buffers.
-- The 'new-session', 'new-window', 'split-window', and 'respawn-pane' commands
-  now understand multiple arguments and handle quoting problems correctly.
-- 'capture-pane' understands '-S-' to mean the start of the pane, and '-E-' to
-  mean the end of the pane.
-- Support for function keys beyond F12 has changed.  The following explains:
-  - F13-F24 are S-F1 to S-F12
-  - F25-F36 are C-F1 to C-F12
-  - F37-F48 are C-S-F1 to C-S-F12
-  - F49-F60 are M-F1 to M-F12
-  - F61-F63 are M-S-F1 to M-S-F3
- Therefore, F13 becomes a binding of S-F1, etc.
-- Support using pane id as part of session or window specifier (so % means
-  session-of-1 or window-of-1) and window id as part of session
-  (so @1 means session-of-@1).
-- 'copy-pipe' command now understands formats via -F
-- 'if-shell'  command now understands formats via -F
-- 'split-window' and 'join-window' understand -b to create the pane to the left
-  or above the target pane
+* Tue May 12 2015 Anton Novojilov <andy@essentialkaos.com> - 2.0-0
+- Updated to 2.0
 
 * Wed Mar 26 2014 Anton Novojilov <andy@essentialkaos.com> - 1.9a-0
-- Updated to version 1.9a
+- Updated to 1.9a
 
 * Wed Mar 26 2014 Anton Novojilov <andy@essentialkaos.com> - 1.9-0
-- Updated to version 1.9
+- Updated to 1.9
 
 * Sun Jul 21 2013 Anton Novojilov <andy@essentialkaos.com> - 1.8-0
-- Updated to version 1.8
+- Updated to 1.8

--- a/ucarp/SOURCES/ucarp-1.5.2-sighup.patch
+++ b/ucarp/SOURCES/ucarp-1.5.2-sighup.patch
@@ -1,0 +1,10 @@
+--- src/carp.c~	2010-01-31 15:59:12.000000000 -0600
++++ src/carp.c	2012-10-25 09:25:54.949976635 -0500
+@@ -762,6 +762,7 @@
+     
+     if (shutdown_at_exit != 0) {
+         (void) signal(SIGINT, sighandler_exit);
++        (void) signal(SIGHUP, sighandler_exit);
+         (void) signal(SIGQUIT, sighandler_exit);
+         (void) signal(SIGTERM, sighandler_exit);
+     }

--- a/ucarp/SOURCES/ucarp.init
+++ b/ucarp/SOURCES/ucarp.init
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+# ucarp        Startup script for ucarp service
+
+# chkconfig: - 85 15
+# processname: ucarp
+# config: /etc/sysconfig/ucarp
+# pidfile: /var/run/ucarp.pid
+# description: Common Address Redundancy Protocol (CARP)
+
+### BEGIN INIT INFO
+# Provides: ucarp
+# Required-Start: $local_fs $remote_fs $network
+# Required-Stop: $local_fs $remote_fs $network
+# Default-Start: 2 3 4 5
+# Default-Stop: 0 1 6
+# Short-Description: start and stop ucarp
+### END INIT INFO
+
+###############################################################################
+
+source /etc/init.d/kaosv
+
+###############################################################################
+
+kv[prog_name]="ucarp"
+kv[search_pattern]="ucarp"
+
+kv.readSysconfig
+
+binary=${BINARY:-/usr/sbin/ucarp}
+conf_dir=${CONFDIR:-/etc/ucarp}
+
+###############################################################################
+
+kv.addCommandVars "stop" "force"
+
+kv.addHandler "start" "startServiceHandler"
+kv.addHandler "stop"  "stopServiceHandler"
+
+###############################################################################
+
+prepare() {
+  local has_errors=""
+
+  [[ ! -f $binary ]] && has_errors=true && kv.error "Error! File <$binary> is not exist"
+  [[ ! -x $binary ]] && has_errors=true && kv.error "Error! File <$binary> is not executable"
+
+  [[ ! -f $conf_dir ]] && has_errors=true && kv.error "Error! Directory <$conf_dir> is not exist"
+  [[ ! -r $conf_dir ]] && has_errors=true && kv.error "Error! Directory <$conf_dir> is not readable"
+
+  [[ $has_errors ]] && kv.exit $ACTION_ERROR
+}
+
+startServiceHandler() {
+  kv.run "$binary $conf_file"
+
+  [[ $? -ne $ACTION_OK ]] && return $ACTION_ERROR
+
+  kv.getStartStatus
+
+  return $?
+}
+
+stopServiceHandler() {
+  local pid=`kv.getPid`
+
+  kv.sendSignal "$SIGNAL_TERM"
+
+  if kv.getStopStatus ; then
+    return $ACTION_OK
+  else
+    if [[ -n "$1" ]] ; then
+      kv.killProcess $pid 
+    fi
+
+    return $ACTION_ERROR
+  fi
+}
+
+###############################################################################
+
+prepare
+
+kv.go $@

--- a/ucarp/SOURCES/vip-001.conf.example
+++ b/ucarp/SOURCES/vip-001.conf.example
@@ -1,0 +1,10 @@
+# Virtual IP configuration file for UCARP
+# The number (from 001 to 255) in the name of the file is the identifier
+
+# In the simple scenario, you want a single virtual IP address from the _same_
+# network to be taken over by one of the routers.
+VIP_ADDRESS="10.0.0.254"
+
+# In more complex scenarios, check the "vip-common" file for values to override
+# and how to add options.
+

--- a/ucarp/SOURCES/vip-common.conf
+++ b/ucarp/SOURCES/vip-common.conf
@@ -1,0 +1,8 @@
+# Common VIP settings which can be overridden in individual vip-<nnnn>.conf
+PASSWORD="love"
+BIND_INTERFACE="eth0"
+SOURCE_ADDRESS=""
+
+# If you have extra options to add, see "ucarp --help" output
+OPTIONS="--shutdown --preempt"
+

--- a/ucarp/SOURCES/vip-down
+++ b/ucarp/SOURCES/vip-down
@@ -1,0 +1,5 @@
+#!/bin/sh
+exec 2>/dev/null
+
+/sbin/ip address del "$2"/32 dev "$1"
+

--- a/ucarp/SOURCES/vip-up
+++ b/ucarp/SOURCES/vip-up
@@ -1,0 +1,5 @@
+#!/bin/sh
+exec 2>/dev/null
+
+/sbin/ip address add "$2"/32 dev "$1"
+

--- a/ucarp/ucarp.spec
+++ b/ucarp/ucarp.spec
@@ -1,0 +1,145 @@
+########################################################################################
+
+%define _posixroot        /
+%define _root             /root
+%define _bin              /bin
+%define _sbin             /sbin
+%define _srv              /srv
+%define _home             /home
+%define _opt              /opt
+%define _lib32            %{_posixroot}lib
+%define _lib64            %{_posixroot}lib64
+%define _libdir32         %{_prefix}%{_lib32}
+%define _libdir64         %{_prefix}%{_lib64}
+%define _logdir           %{_localstatedir}/log
+%define _rundir           %{_localstatedir}/run
+%define _lockdir          %{_localstatedir}/lock/subsys
+%define _cachedir         %{_localstatedir}/cache
+%define _spooldir         %{_localstatedir}/spool
+%define _crondir          %{_sysconfdir}/cron.d
+%define _loc_prefix       %{_prefix}/local
+%define _loc_exec_prefix  %{_loc_prefix}
+%define _loc_bindir       %{_loc_exec_prefix}/bin
+%define _loc_libdir       %{_loc_exec_prefix}/%{_lib}
+%define _loc_libdir32     %{_loc_exec_prefix}/%{_lib32}
+%define _loc_libdir64     %{_loc_exec_prefix}/%{_lib64}
+%define _loc_libexecdir   %{_loc_exec_prefix}/libexec
+%define _loc_sbindir      %{_loc_exec_prefix}/sbin
+%define _loc_bindir       %{_loc_exec_prefix}/bin
+%define _loc_datarootdir  %{_loc_prefix}/share
+%define _loc_includedir   %{_loc_prefix}/include
+%define _loc_mandir       %{_loc_datarootdir}/man
+%define _rpmstatedir      %{_sharedstatedir}/rpm-state
+%define _pkgconfigdir     %{_libdir}/pkgconfig
+
+%define __ln              %{_bin}/ln
+%define __touch           %{_bin}/touch
+%define __service         %{_sbin}/service
+%define __chkconfig       %{_sbin}/chkconfig
+%define __ldconfig        %{_sbin}/ldconfig
+%define __groupadd        %{_sbindir}/groupadd
+%define __useradd         %{_sbindir}/useradd
+
+########################################################################################
+
+Summary:              Common Address Redundancy Protocol (CARP)
+Name:                 ucarp
+Version:              1.5.2
+Release:              8%{?dist}
+License:              MIT and BSD
+Group:                System Environment/Daemons
+URL:                  http://www.ucarp.org
+
+Source0:              http://download.pureftpd.org/pub/%{name}/%{name}-%{version}.tar.bz2
+Source1:              %{name}.init
+Source2:              vip-001.conf.example
+Source3:              vip-common.conf
+Source4:              vip-up
+Source5:              vip-down
+
+Patch0:               ucarp-1.5.2-sighup.patch
+
+BuildRoot:            %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+
+BuildRequires:        autoconf automake libtool gettext libpcap-devel make gcc
+
+Requires(post):       /sbin/chkconfig
+Requires(preun):      /sbin/chkconfig /sbin/service
+Requires(postun):     /sbin/service
+
+Provides:             %{name} = %{version}-%{release}
+
+########################################################################################
+
+%description
+UCARP allows a couple of hosts to share common virtual IP addresses in order
+to provide automatic failover. It is a portable userland implementation of the
+secure and patent-free Common Address Redundancy Protocol (CARP, OpenBSD's
+alternative to the patents-bloated VRRP).
+Strong points of the CARP protocol are: very low overhead, cryptographically
+signed messages, interoperability between different operating systems and no
+need for any dedicated extra network link between redundant hosts.
+
+########################################################################################
+
+%prep
+%setup -q
+
+%patch0 -p0
+
+%build
+%configure
+
+%{__make} %{?_smp_mflags}
+
+%install
+%{__rm} -rf %{buildroot}
+
+%{__make} install DESTDIR=%{buildroot}
+
+install -dm 755 %{buildroot}%{_sysconfdir}/%{name}
+install -dm 755 %{buildroot}%{_libexecdir}/%{name}
+install -dm 755 %{buildroot}%{_initddir}
+
+install -pm 755 %{SOURCE1} %{buildroot}%{_initddir}/%{name}
+
+install -pm 600 %{SOURCE2} %{SOURCE3} %{buildroot}%{_sysconfdir}/%{name}/
+install -pm 700 %{SOURCE4} %{SOURCE5} %{buildroot}%{_libexecdir}/%{name}/
+
+%clean
+%{__rm} -rf %{buildroot}
+
+%pre
+# Legacy, in case we update from an older package where the service was "carp"
+if [[ -f %{_sysconfdir}/carp ]] ; then
+  %{__service} carp stop &>/dev/null || :
+  %{__chkconfig} --del carp
+fi
+
+%post
+%{__chkconfig} --add %{name}
+
+%preun
+if [[ $1 -eq 0 ]] ; then
+  %{__service} %{name} stop &>/dev/null || :
+  %{__chkconfig} --del %{name}
+fi
+
+########################################################################################
+
+%files
+%defattr(-,root,root,-)
+%doc AUTHORS COPYING ChangeLog NEWS README
+%attr(0700,root,root) %dir %{_sysconfdir}/%{name}
+%config(noreplace) %{_libexecdir}/%{name}/
+%config(noreplace) %{_sysconfdir}/%{name}/vip-common.conf
+%{_sysconfdir}/%{name}/vip-001.conf.example
+%{_initddir}/%{name}
+%{_sbindir}/%{name}
+%{_datadir}/locale/*
+
+########################################################################################
+
+%changelog
+* Mon Nov 23 2015 Anton Novojilov <andy@essentialkaos.com> - 1.5.2-8
+- Initial build


### PR DESCRIPTION
Updated:
- createrepo_c
- ejabberd
- ffmpeg-kaos
- geos
- git
- golang
- h2o
- haproxy
- libmicrohttpd
- memcached
- mercurial
- postgis2
- rabbitmq
- tmux
- Deamonize updated to 1.7.7
- Erlang18 updated to 18.2.1
- Git updated to 2.6.4
- GoAccess update 0.9.7
- ffmpeg-kaos updated to 2.8.4
- H2O updated to 1.6.1 
- HAProxy updated to 1.6.3
- MMGeoIp data updated to latest version
- PGBouncer update to 1.7
- Mercurial updated to 3.6.2 
- RabbitMQ-Server updated to 3.6.0
- Redis updated to 3.0.6
- Snort updated to 2.9.8.0
- tcpkali updated to 0.7
