### PR TITLE
httpie: updated to 0.9.3.

### DIFF
--- a/httpie.spec
+++ b/httpie.spec
@@ -32,7 +32,7 @@
 
 Summary:           A Curl-like tool for humans
 Name:              httpie
-Version:           0.8.0
+Version:           0.9.3
 Release:           0%{?dist}
 License:           BSD
 Group:             Applications/Internet
@@ -92,5 +92,8 @@ sed -i 's/requests>=2.0.0/requests>=1.1.0/' setup.py
 ###############################################################################
 
 %changelog
+* Thu Mar 31 2016 Gleb Goncharov <yum@gongled.ru> - 0.9.3-0
+- Updated to latest release
+
 * Tue Jul 29 2014 Anton Novojilov <andy@essentialkaos.com> - 0.8.0-0
 - Initial build


### PR DESCRIPTION
Issue "[ImportError: cannot import name is_windows](https://github.com/jkbrzt/httpie/issues/314)" fixed.
