### PR TITLE
libnut: spec refactoring

### DIFF
--- a/libnut/SOURCES/libnut-config.patch
+++ b/libnut/SOURCES/libnut-config.patch
@@ -1,0 +1,18 @@
+diff -urN libnut-orig/config.mak libnut/config.mak
+--- libnut-orig/config.mak	2016-04-15 10:57:56.006213992 +0300
++++ libnut/config.mak	2016-04-15 11:00:02.086213909 +0300
+@@ -1,12 +1,7 @@
+-PREFIX = /usr/local
+ prefix = $(DESTDIR)$(PREFIX)
+-
+-#CFLAGS += -DDEBUG
+-
+-CFLAGS += -Os -fomit-frame-pointer -g -Wall
+-
++CFLAGS += -Os -fomit-frame-pointer -g -Wall -fPIC
+ CFLAGS += -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
+-
++#CFLAGS += -DDEBUG
+ CC = cc
+ RANLIB  = ranlib
+ AR = ar

--- a/libnut/SOURCES/libnut-makefile.patch
+++ b/libnut/SOURCES/libnut-makefile.patch
@@ -1,0 +1,69 @@
+diff -urN libnut-orig/Makefile libnut/Makefile
+--- libnut-orig/Makefile	2016-04-15 11:06:56.371213636 +0300
++++ libnut/Makefile	2016-04-15 11:11:58.374213437 +0300
+@@ -14,47 +14,49 @@
+ 	$(RANLIB) $@
+ 
+ libnut/libnut.so: $(LIBNUT_OBJS)
+-	$(CC) $(CFLAGS) -shared $^ -o $@
++	$(CC) $(LDFLAGS) $(CFLAGS) -shared $^ -o $@.0 -Wl,-soname,libnut.so.0
++	ln -sf libnut.so.0 libnut/libnut.so
+ 
+ $(LIBNUT_OBJS): libnut/priv.h libnut/libnut.h
+ 
+ nututils: $(NUTUTILS_PROGS)
+ 
+ $(NUTMERGE_OBJS): nututils/nutmerge.h
+-nututils/nutmerge: $(NUTMERGE_OBJS) libnut/libnut.a
++nututils/nutmerge: $(NUTMERGE_OBJS) libnut/libnut.so
+ 
+ $(NUTUTILS_PROGS): CFLAGS += -Ilibnut
+ 
+-install: install-libnut install-nututils
++install: install-libnut install-libnut-shared install-libnut-headers install-nututils
+ 
+ install-libnut: libnut install-libnut-headers
+-	install -d $(prefix)/lib
+-	install -m 644 libnut/libnut.a $(prefix)/lib
++	install -d $(DESTDIR)$(LIBDIR)
++	install -m 644 libnut/libnut.a $(DESTDIR)$(LIBDIR)
+ 
+ install-libnut-shared: libnut/libnut.so install-libnut-headers
+-	install -d $(prefix)/lib
+-	install -m 644 libnut/libnut.so $(prefix)/lib
++	install -d $(DESTDIR)$(LIBDIR)
++	install -m 644 libnut/libnut.so.0 $(DESTDIR)$(LIBDIR)
++	ln -sf libnut.so.0 $(DESTDIR)$(LIBDIR)/libnut.so
+ 
+ install-libnut-headers:
+-	install -d $(prefix)/include
+-	install -m 644 libnut/libnut.h $(prefix)/include
++	install -d $(DESTDIR)$(PREFIX)/include
++	install -m 644 libnut/libnut.h $(DESTDIR)$(PREFIX)/include
+ 
+ install-nututils: nututils
+-	install -d $(prefix)/bin
+-	install -m 755 $(NUTUTILS_PROGS) $(prefix)/bin
++	install -d $(DESTDIR)$(PREFIX)/bin
++	install -m 755 $(NUTUTILS_PROGS) $(DESTDIR)$(PREFIX)/bin
+ 
+ uninstall: uninstall-libnut uninstall-nututils
+ 
+ uninstall-libnut:
+-	rm -f $(prefix)/lib/libnut.a
+-	rm -f $(prefix)/lib/libnut.so
+-	rm -f $(prefix)/include/libnut.h
++	rm -f $(DESTDIR)$(LIBDIR)/libnut.a
++	rm -f $(DESTDIR)$(LIBDIR)/libnut.so*
++	rm -f $(DESTDIR)$(PREFIX)/include/libnut.h
+ 
+ uninstall-nututils:
+-	rm -f $(addprefix $(prefix)/bin/, $(subst nututils/,,$(NUTUTILS_PROGS)))
++	rm -f $(addprefix $(DESTDIR)$(PREFIX)/bin/, $(subst nututils/,,$(NUTUTILS_PROGS)))
+ 
+ clean distclean:
+-	rm -f libnut/*\~ libnut/*.o libnut/libnut.so libnut/libnut.a
++	rm -f libnut/*\~ libnut/*.o libnut/libnut.so* libnut/libnut.a
+ 	rm -f nututils/*\~ nututils/*.o  $(NUTUTILS_PROGS)
+ 
+ .PHONY: all libnut nututils install* uninstall* clean distclean

--- a/libnut/libnut.spec
+++ b/libnut/libnut.spec
@@ -1,0 +1,96 @@
+###############################################################################
+
+Summary:            Library for creating and demuxing NUT files
+Name:               libnut
+Version:            0.0.0
+Release:            0_f3476bb%{?dist}
+License:            MIT
+Group:              Development/Libraries
+URL:                https://github.com/TimothyGu/libnut
+
+Source0:            %{name}-%{version}.tar.gz
+
+Patch0:             %{name}-makefile.patch
+Patch1:             %{name}-config.patch
+
+BuildRoot:          %{_tmppath}/%{name}-%{version}-%{release}-root
+
+BuildRequires:      gcc-c++ make
+
+###############################################################################
+
+%description
+NUT is a patent-free, multimedia container format originally conceived
+by a few MPlayer and FFmpeg developers that were dissatisfied with the
+limitations of all currently available multimedia container formats
+such as AVI, Ogg or Matroska. It aims to be simple, flexible,
+extensible, compact and error resistant (error resilient), thus
+addressing most if not all of the shortcomings present in alternative
+formats, like excessive CPU and size overhead, file size limits,
+inability to allow fine grained seeking or restrictions on the type of
+data they can contain.
+
+libnut is a free library for creating and demuxing NUT files. It
+supports frame accurate seeking for active streams, recovery from
+errors and dynamic index generation during playback.
+
+###############################################################################
+
+%package devel
+Summary:            Development files for NUT library
+Group:              Development/Libraries
+
+Requires:           %{name}-%{version}
+
+%description devel
+Header file for NUT library.
+
+###############################################################################
+
+%prep
+%setup -q
+%patch0 -p1
+%patch1 -p1
+
+%build
+make %{?_smp_mflags}
+
+%install
+rm -rf %{buildroot}
+make install DESTDIR=%{buildroot} \
+    PREFIX=%{_prefix} \
+    LIBDIR=%{_libdir}
+
+%clean
+rm -rf %{buildroot}
+
+###############################################################################
+
+%post
+/sbin/ldconfig
+
+%postun
+/sbin/ldconfig
+
+###############################################################################
+
+%files
+%defattr(644,root,root,755)
+%doc COPYING README
+%attr(755,root,root) %{_bindir}/nutmerge
+%attr(755,root,root) %{_bindir}/nutindex
+%attr(755,root,root) %{_bindir}/nutparse
+%attr(755,root,root) %{_libdir}/libnut.so.0
+
+%files devel
+%defattr(644,root,root,755)
+%attr(755,root,root) %{_libdir}/libnut.so
+%attr(755,root,root) %{_libdir}/libnut.a
+%{_includedir}/libnut.h
+
+###############################################################################
+
+%changelog
+* Sat Nov 21 2009 Axel Thimm <Axel.Thimm@ATrpms.net>
+- Initial build.
+

--- a/libnut/libnut.spec
+++ b/libnut/libnut.spec
@@ -1,9 +1,51 @@
 ###############################################################################
 
+# rpmbuilder:github   TimothyGu/libnut
+# rpmbuilder:revision f3476bb3ccf5acc1b0be76fc881f1e804c475391
+
+###############################################################################
+
+%define _posixroot        /
+%define _root             /root
+%define _bin              /bin
+%define _sbin             /sbin
+%define _srv              /srv
+%define _home             /home
+%define _lib32            %{_posixroot}lib
+%define _lib64            %{_posixroot}lib64
+%define _libdir32         %{_prefix}%{_lib32}
+%define _libdir64         %{_prefix}%{_lib64}
+%define _logdir           %{_localstatedir}/log
+%define _rundir           %{_localstatedir}/run
+%define _lockdir          %{_localstatedir}/lock
+%define _cachedir         %{_localstatedir}/cache
+%define _spooldir         %{_localstatedir}/spool
+%define _loc_prefix       %{_prefix}/local
+%define _loc_exec_prefix  %{_loc_prefix}
+%define _loc_bindir       %{_loc_exec_prefix}/bin
+%define _loc_libdir       %{_loc_exec_prefix}/%{_lib}
+%define _loc_libdir32     %{_loc_exec_prefix}/%{_lib32}
+%define _loc_libdir64     %{_loc_exec_prefix}/%{_lib64}
+%define _loc_libexecdir   %{_loc_exec_prefix}/libexec
+%define _loc_sbindir      %{_loc_exec_prefix}/sbin
+%define _loc_bindir       %{_loc_exec_prefix}/bin
+%define _loc_datarootdir  %{_loc_prefix}/share
+%define _loc_includedir   %{_loc_prefix}/include
+%define _rpmstatedir      %{_sharedstatedir}/rpm-state
+%define _pkgconfigdir     %{_libdir}/pkgconfig
+
+%define __ln              %{_bin}/ln
+%define __touch           %{_bin}/touch
+%define __service         %{_sbin}/service
+%define __ldconfig        %{_sbin}/ldconfig
+%define __chkconfig       %{_sbin}/chkconfig
+
+###############################################################################
+
 Summary:            Library for creating and demuxing NUT files
 Name:               libnut
 Version:            0.0.0
-Release:            0_f3476bb%{?dist}
+Release:            0%{?dist}
 License:            MIT
 Group:              Development/Libraries
 URL:                https://github.com/TimothyGu/libnut
@@ -23,16 +65,13 @@ BuildRequires:      gcc-c++ make
 NUT is a patent-free, multimedia container format originally conceived
 by a few MPlayer and FFmpeg developers that were dissatisfied with the
 limitations of all currently available multimedia container formats
-such as AVI, Ogg or Matroska. It aims to be simple, flexible,
-extensible, compact and error resistant (error resilient), thus
-addressing most if not all of the shortcomings present in alternative
-formats, like excessive CPU and size overhead, file size limits,
-inability to allow fine grained seeking or restrictions on the type of
-data they can contain.
+such as AVI, Ogg or Matroska. 
 
-libnut is a free library for creating and demuxing NUT files. It
-supports frame accurate seeking for active streams, recovery from
-errors and dynamic index generation during playback.
+It aims to be simple, flexible, extensible, compact and error resistant
+(error resilient), thus addressing most if not all of the shortcomings 
+present in alternative formats, like excessive CPU and size overhead, 
+file size limits, inability to allow fine grained seeking or restrictions 
+on the type of data they can contain.
 
 ###############################################################################
 
@@ -43,7 +82,9 @@ Group:              Development/Libraries
 Requires:           %{name}-%{version}
 
 %description devel
-Header file for NUT library.
+libnut is a free library for creating and demuxing NUT files. It
+supports frame accurate seeking for active streams, recovery from
+errors and dynamic index generation during playback.
 
 ###############################################################################
 
@@ -91,6 +132,6 @@ rm -rf %{buildroot}
 ###############################################################################
 
 %changelog
-* Sat Nov 21 2009 Axel Thimm <Axel.Thimm@ATrpms.net>
+* Fri Apr 15 2016 Gleb Goncharov <yum@gongled.ru> - 0.0.0-0
 - Initial build.
 

--- a/libnut/libnut.spec
+++ b/libnut/libnut.spec
@@ -116,18 +116,18 @@ rm -rf %{buildroot}
 ###############################################################################
 
 %files
-%defattr(644,root,root,755)
+%defattr(-,root,root,-)
 %doc COPYING README
-%attr(755,root,root) %{_bindir}/nutmerge
-%attr(755,root,root) %{_bindir}/nutindex
-%attr(755,root,root) %{_bindir}/nutparse
-%attr(755,root,root) %{_libdir}/libnut.so.0
+%{_bindir}/nutmerge
+%{_bindir}/nutindex
+%{_bindir}/nutparse
+%{_libdir}/%{name}.so.0
 
 %files devel
-%defattr(644,root,root,755)
-%attr(755,root,root) %{_libdir}/libnut.so
-%attr(755,root,root) %{_libdir}/libnut.a
-%{_includedir}/libnut.h
+%defattr(-,root,root,-)
+%{_libdir}/%{name}.so
+%{_libdir}/%{name}.a
+%{_includedir}/%{name}.h
 
 ###############################################################################
 


### PR DESCRIPTION
I prepared `libnut` and `libnub-devel` package for NUT multimedia container library. It's optional requirement for FFmpeg. Unfortunately, I don't know where is source code of this project. I've found [this one](https://github.com/TimothyGu/libnut) and built package using this command:

```
rpmbuilder libnut.spec -V --git https://github.com/TimothyGu/libnut.git -rr f3476bb3ccf5acc1b0be76fc881f1e804c475391
```
