### PR TITLE
syslog-ng: updated to latest version (3.7.3)

### DIFF
--- a/syslog-ng/SOURCES/syslog-ng.init
+++ b/syslog-ng/SOURCES/syslog-ng.init
@@ -26,7 +26,7 @@ kv[log]="/var/log/syslog-ng.log"
 
 kv.addCommand "start"        "Start ${kv[prog_name]}"
 kv.addCommand "stop"         "Stop ${kv[prog_name]}"
-kv.addCommand "restart"      "Restart (stop+start) ${kv[prog_name]}" "restart"
+kv.addCommand "restart"      "Restart (stop+start) ${kv[prog_name]}"
 kv.addCommand "status"       "Show current status of ${kv[prog_name]}"
 kv.addCommand "check"        "Validate config" "check"
 kv.addCommand "reload"       "Reload ${kv[prog_name]}" "reload"

--- a/syslog-ng/syslog-ng.spec
+++ b/syslog-ng/syslog-ng.spec
@@ -153,9 +153,9 @@ fi
 ###############################################################################
 
 %changelog
-* Mon Mar 21 2016 Gleb Goncharov <yum@gongled.me> - 3.7.3-0
+* Mon Apr 25 2016 Gleb Goncharov <yum@gongled.me> - 3.7.3-0
 - Updated to latest version.
-- Fixed 'restart' handler in SysV script. 
+- Fixed 'restart' handler in SysV init-script. 
 
 * Mon Mar 21 2016 Gleb Goncharov <yum@gongled.me> - 3.7.2-0
 - Initial build

--- a/syslog-ng/syslog-ng.spec
+++ b/syslog-ng/syslog-ng.spec
@@ -48,7 +48,7 @@
 
 Summary:            Next generation logging application
 Name:               syslog-ng
-Version:            3.7.2
+Version:            3.7.3
 Release:            0%{?dist}
 License:            GPL
 Group:              System Environment/Daemons
@@ -153,5 +153,9 @@ fi
 ###############################################################################
 
 %changelog
+* Mon Mar 21 2016 Gleb Goncharov <yum@gongled.me> - 3.7.3-0
+- Updated to latest version.
+- Fixed 'restart' handler in SysV script. 
+
 * Mon Mar 21 2016 Gleb Goncharov <yum@gongled.me> - 3.7.2-0
 - Initial build


### PR DESCRIPTION
- `syslog-ng` updated to 3.7.3.
- Fixed restart handler in `syslog-ng.init` 
