### PR TITLE
libnut: updated to latest revision (r690)

### DIFF
--- a/libnut/libnut.spec
+++ b/libnut/libnut.spec
@@ -1,14 +1,14 @@
 ###############################################################################
 
-# rpmbuilder:github   TimothyGu/libnut
-# rpmbuilder:revision f3476bb3ccf5acc1b0be76fc881f1e804c475391
+# rpmbuilder:svn      svn://svn.mplayerhq.hu/nut/src/trunk
+# rpmbuilder:revision r690
 
 ###############################################################################
 
 Summary:            Library for creating and demuxing NUT files
 Name:               libnut
 Version:            0.0.0
-Release:            0%{?dist}
+Release:            1%{?dist}
 License:            MIT
 Group:              Development/Libraries
 URL:                https://github.com/TimothyGu/libnut
@@ -23,6 +23,7 @@ BuildRoot:          %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -
 BuildRequires:      gcc make
 
 Provides:           %{name} = %{version}-%{release}
+Provides:           %{name}.so.0 = %{version}-%{release}
 
 ###############################################################################
 
@@ -93,5 +94,9 @@ rm -rf %{buildroot}
 ###############################################################################
 
 %changelog
-* Fri Apr 15 2016 Gleb Goncharov <yum@gongled.ru> - 0.0.0-0
+* Fri May 13 2016 Gleb Goncharov <inbox@gongled.ru> - 0.0.0-1
+- Updated to latest version (r690)
+
+* Fri Apr 15 2016 Gleb Goncharov <inbox@gongled.ru> - 0.0.0-0
 - Initial build
+

--- a/libnut/libnut.spec
+++ b/libnut/libnut.spec
@@ -23,7 +23,6 @@ BuildRoot:          %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -
 BuildRequires:      gcc make
 
 Provides:           %{name} = %{version}-%{release}
-Provides:           %{name}.so.0 = %{version}-%{release}
 
 ###############################################################################
 


### PR DESCRIPTION
I've found that the latest versions are available on [Launchpad website](https://code.launchpad.net/libnut) and there are newer than we built before. Unfortunately, I couldn't prepare working spec for CentOS 7. Keep in mind, that `ffmpeg-kaos` probably shouldn't be compiled with `--enable-libnut` anymore.
