### PR TITLE
zabbix: removed unnecessary patch

### DIFF
--- a/zabbix/zabbix.spec
+++ b/zabbix/zabbix.spec
@@ -51,7 +51,7 @@
 
 Name:                 zabbix
 Version:              3.0.3
-Release:              0%{?dist}
+Release:              1%{?dist}
 Summary:              The Enterprise-class open source monitoring solution
 Group:                Applications/Internet
 License:              GPLv2+
@@ -978,6 +978,9 @@ fi
 ################################################################################
 
 %changelog
+* Thu Jun 23 2016 Gleb Goncharov <inbox@gongled.ru> - 3.0.3-1
+- removed unnecessary patch for fping3 support.
+
 * Sun Jun 19 2016 Anton Novojilov <andy@essentialkaos.com> - 3.0.3-0
 - added script name and command into a script execution form
 - enabled Chinese (China) translation to be displayed by default

--- a/zabbix/zabbix.spec
+++ b/zabbix/zabbix.spec
@@ -73,7 +73,6 @@ Source23:             %{name}-tmpfiles.conf
 
 Patch0:               config.patch
 Patch1:               fonts-config.patch
-Patch2:               fping3-sourceip-option.patch
 
 BuildRoot:            %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
@@ -333,9 +332,6 @@ Zabbix web frontend for PostgreSQL
 
 %patch0 -p1
 %patch1 -p1
-%if 0%{?rhel} >= 7
-%patch2 -p1
-%endif
 
 # remove .htaccess files
 rm -f frontends/php/app/.htaccess


### PR DESCRIPTION
I've found that fping3 couldn't be applied on Zabbix 3.0.3 for CentOS 7. I suppose that it should be excluded from spec.
