### PR TITLE
elasticsearch-curator: new package added

### DIFF
--- a/elasticsearch-curator.spec
+++ b/elasticsearch-curator.spec
@@ -16,7 +16,7 @@ Source:         https://github.com/elastic/%{package_name}/archive/v%{version}.t
 
 BuildRequires:  python-devel python-setuptools
 
-BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}
+BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildArch:      noarch
 

--- a/elasticsearch-curator.spec
+++ b/elasticsearch-curator.spec
@@ -1,0 +1,58 @@
+########################################################################################
+
+%define package_name      curator
+
+########################################################################################
+
+Summary:        Utility for tending Elasticsearch indices 
+Name:           elasticsearch-%{package_name}
+Version:        4.0.6
+Release:        0%{?dist}
+License:        ASLv2.0
+Group:          Development/Libraries
+URL:            https://github.com/elastic/curator
+
+Source:         https://github.com/elastic/%{package_name}/archive/v%{version}.tar.gz
+
+BuildRequires:  python-devel python-setuptools
+
+BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}
+
+BuildArch:      noarch
+
+Provides:       %{name} = %{verion}-%{release}
+
+########################################################################################
+
+%description
+Like a museum curator manages the exhibits and collections on display, Elasticsearch 
+Curator helps you curate, or manage your indices.
+
+########################################################################################
+
+%prep
+%setup -qn %{package_name}-%{version}
+
+%clean
+rm -rf %{buildroot}
+
+%build
+python setup.py build
+
+%install
+rm -rf %{buildroot}
+python setup.py install --prefix=%{_prefix} --root=%{buildroot}
+
+########################################################################################
+
+%files
+%defattr(-,root,root,-)
+%{python_sitelib}/*
+%{_bindir}/%{package_name}
+%{_bindir}/es_repo_mgr
+
+########################################################################################
+
+%changelog
+* Mon Sep 05 2016 Gleb Goncharov <ggoncharov@simtechdev.com> - 4.0.6-0
+- Initial build

--- a/python-elasticsearch.spec
+++ b/python-elasticsearch.spec
@@ -1,24 +1,23 @@
 ########################################################################################
 
-%define package_name      curator
+%define package_name      elasticsearch
+%define source_name       %{package_name}-py
 
 ########################################################################################
 
-Summary:        Utility for tending Elasticsearch indices 
-Name:           elasticsearch-%{package_name}
-Version:        4.0.6
+Summary:        Python client for Elasticsearch 2.x
+Name:           python-%{package_name}
+Version:        2.4.0
 Release:        0%{?dist}
 License:        ASLv2.0
 Group:          Development/Libraries
-URL:            https://github.com/elastic/curator
+URL:            https://github.com/elastic/elasticsearch-py
 
-Source:         https://github.com/elastic/%{package_name}/archive/v%{version}.tar.gz
+Source:         https://github.com/elastic/%{source_name}/archive/%{version}.tar.gz
 
 BuildRequires:  python-devel python-setuptools
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
-
-Requires:       python-elasticsearch >= 2.0
 
 BuildArch:      noarch
 
@@ -27,13 +26,14 @@ Provides:       %{name} = %{verion}-%{release}
 ########################################################################################
 
 %description
-Like a museum curator manages the exhibits and collections on display, Elasticsearch 
-Curator helps you curate, or manage your indices.
+Official low-level client for Elasticsearch. Its goal is to provide common ground for 
+all Elasticsearch-related code in Python; because of this it tries to be opinion-free 
+and very extendable.
 
 ########################################################################################
 
 %prep
-%setup -qn %{package_name}-%{version}
+%setup -qn %{source_name}-%{version}
 
 %clean
 rm -rf %{buildroot}
@@ -50,11 +50,9 @@ python setup.py install --prefix=%{_prefix} --root=%{buildroot}
 %files
 %defattr(-,root,root,-)
 %{python_sitelib}/*
-%{_bindir}/%{package_name}
-%{_bindir}/es_repo_mgr
 
 ########################################################################################
 
 %changelog
-* Mon Sep 05 2016 Gleb Goncharov <ggoncharov@simtechdev.com> - 4.0.6-0
+* Tue Sep 06 2016 Gleb Goncharov <ggoncharov@simtechdev.com> - 2.4.0-0
 - Initial build


### PR DESCRIPTION
I've prepared `elasticsearch-curator` package for managing ElasticSearch indices. Unfortunately, package in EPEL doesn't work with ES higher 2.0. So that's why it might be very useful for modern installations.
