### PR TITLE
tcpflow: new package added

### DIFF
--- a/tcpflow.spec
+++ b/tcpflow.spec
@@ -1,0 +1,58 @@
+###############################################################################
+
+Summary:              Network traffic recorder
+Name:                 tcpflow
+Version:              1.4.5
+Release:              0%{?dist}
+License:              GPLv3
+Group:                Development/Tools
+URL:                  https://github.com/simsong/tcpflow
+
+Source:               http://digitalcorpora.org/downloads/%{name}/%{name}-%{version}.tar.gz
+
+BuildRoot:            %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+
+Requires:             boost >= 1.53.0 libpcap
+
+BuildRequires:        gcc >= 3.0 autoconf m4 >= 1.4 make
+BuildRequires:        boost-devel >= 1.53.0 libpcap-devel
+
+###############################################################################
+
+%description
+tcpflow is a program that captures data transmitted as part of TCP
+connections (flows), and stores the data in a way that is convenient for
+protocol analysis or debugging. A program like 'tcpdump' shows a summary of
+packets seen on the wire, but usually doesn't store the data that's actually
+being transmitted. In contrast, tcpflow reconstructs the actual data streams
+and stores each flow in a separate file for later analysis.
+
+###############################################################################
+
+%prep
+%setup -q
+
+%build
+%configure
+%{__make} %{?_smp_mflags}
+
+%install
+rm -rf %{buildroot}
+%{make_install} PREFIX=%{buildroot}%{prefix}
+
+%clean
+rm -rf %{buildroot}
+
+###############################################################################
+
+%files
+%defattr(-,root,root)
+%doc AUTHORS COPYING ChangeLog NEWS README
+%{_bindir}/%{name}
+%{_mandir}/man1/%{name}.1.gz
+
+###############################################################################
+
+%changelog
+* Wed Dec 07 2016 Gleb Goncharov <g.goncharov@fun-box.ru> - 1.4.5-0
+- Initial build.


### PR DESCRIPTION
Would be nice to have tcpflow as a network traffic recorder to capture and decode HTTP traffic from multiple TCP connections (flows). It might be useful for debugging purposes. Unfortunately, it requires boost-devel >= 1.53.0, so I temporary brought RPMs from ENETRES repository (there is no SRPMS). I need your opinion: should we build yet another boost and put it into EK repository?