### PR TITLE
Yandex.Tank: new package added

### DIFF
--- a/yandex-tank.spec
+++ b/yandex-tank.spec
@@ -54,7 +54,7 @@ BuildArch:          noarch
 BuildRequires:      python-setuptools
 
 Requires:           python-psutil python-requests python-configparser
-Requires:           python-paramiko python-pandas python-numpy python-future
+Requires:           python-paramiko python-pandas numpy python-future
 
 ################################################################################
 

--- a/yandex-tank.spec
+++ b/yandex-tank.spec
@@ -1,0 +1,94 @@
+################################################################################
+
+%{!?python_sitelib: %global python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print get_python_lib(0)")}
+
+################################################################################
+
+%define _posixroot        /
+%define _root             /root
+%define _bin              /bin
+%define _sbin             /sbin
+%define _srv              /srv
+%define _home             /home
+%define _lib32            %{_posixroot}lib
+%define _lib64            %{_posixroot}lib64
+%define _libdir32         %{_prefix}%{_lib32}
+%define _libdir64         %{_prefix}%{_lib64}
+%define _logdir           %{_localstatedir}/log
+%define _rundir           %{_localstatedir}/run
+%define _lockdir          %{_localstatedir}/lock/subsys
+%define _cachedir         %{_localstatedir}/cache
+%define _spooldir         %{_localstatedir}/spool
+%define _crondir          %{_sysconfdir}/cron.d
+%define _loc_prefix       %{_prefix}/local
+%define _loc_exec_prefix  %{_loc_prefix}
+%define _loc_bindir       %{_loc_exec_prefix}/bin
+%define _loc_libdir       %{_loc_exec_prefix}/%{_lib}
+%define _loc_libdir32     %{_loc_exec_prefix}/%{_lib32}
+%define _loc_libdir64     %{_loc_exec_prefix}/%{_lib64}
+%define _loc_libexecdir   %{_loc_exec_prefix}/libexec
+%define _loc_sbindir      %{_loc_exec_prefix}/sbin
+%define _loc_bindir       %{_loc_exec_prefix}/bin
+%define _loc_datarootdir  %{_loc_prefix}/share
+%define _loc_includedir   %{_loc_prefix}/include
+%define _loc_mandir       %{_loc_datarootdir}/man
+%define _rpmstatedir      %{_sharedstatedir}/rpm-state
+%define _pkgconfigdir     %{_libdir}/pkgconfig
+
+################################################################################
+
+Summary:            Extensible load testing utility for unix systems
+Name:               yandex-tank
+Version:            1.8.29
+Release:            0%{?dist}
+License:            LGPL
+Group:              Development/Tools
+URL:                https://github.com/yandex/yandex-tank
+
+Source0:            https://github.com/yandex/%{name}/archive/v%{version}.tar.gz
+
+BuildRoot:          %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+
+BuildArch:          noarch
+
+BuildRequires:      python-setuptools
+
+Requires:           python-psutil python-requests python-configparser
+Requires:           python-paramiko python-pandas python-numpy python-future
+
+################################################################################
+
+%description
+Performance performance measurement tool from Yandex Load team.
+
+################################################################################
+
+%prep
+%setup -q -n %{name}-%{version}
+
+%build
+%{__python} setup.py build
+
+%install
+rm -rf %{buildroot}
+
+%{__python} setup.py install -O1 --skip-build --root %{buildroot}
+
+%clean
+rm -rf %{buildroot}
+
+################################################################################
+
+%files
+%defattr(-,root,root,-)
+%doc AUTHORS LICENSE README.md docs
+%{python_sitelib}/*
+%{_bindir}/%{name}
+%{_bindir}/%{name}-check-ssh
+
+################################################################################
+
+%changelog
+* Mon Dec 12 2016 Gleb Goncharov <ggoncharov@fun-box.ru> - 1.8.29-0
+- Initial build
+


### PR DESCRIPTION
Load benchmarking testing tool from Yandex Team, which uses phantom, BFG, jMeter and experimental pandora as a load generators. It requires Python 2.7, so that will work only on CentOS 7.