### PR TITLE
Add nfs-utils RPM spec

### DIFF
--- a/nfs-utils/SOURCES/id_resolver.conf
+++ b/nfs-utils/SOURCES/id_resolver.conf
@@ -1,0 +1,9 @@
+#
+# nfsidmap(5) - The NFS idmapper upcall program
+# Summary: Used by NFSv4 to map user/group ids into 
+#          user/group names and names into in ids
+# Options:
+# -v         Increases the verbosity of the output to syslog
+# -t timeout Set the expiration timer, in seconds, on the key
+#
+create    id_resolver    *         *    /usr/sbin/nfsidmap %k %d

--- a/nfs-utils/SOURCES/lockd.conf
+++ b/nfs-utils/SOURCES/lockd.conf
@@ -1,0 +1,7 @@
+#
+# To be installed in /etc/modprobe.d
+#
+# Those who have need for lockd to listen on a particular port should
+# uncomment the line below and set the values appropriately.
+#
+#options lockd nlm_tcpport=32803 nlm_udpport=32769

--- a/nfs-utils/SOURCES/nfs-utils-1.2.1-exp-subtree-warn-off.patch
+++ b/nfs-utils/SOURCES/nfs-utils-1.2.1-exp-subtree-warn-off.patch
@@ -1,0 +1,12 @@
+diff -up nfs-utils-1.2.8/support/nfs/exports.c.orig nfs-utils-1.2.8/support/nfs/exports.c
+--- nfs-utils-1.2.8/support/nfs/exports.c.orig	2013-09-24 15:35:26.022548905 -0400
++++ nfs-utils-1.2.8/support/nfs/exports.c	2013-09-24 15:35:51.274547991 -0400
+@@ -508,7 +508,7 @@ void fix_pseudoflavor_flags(struct expor
+ static int
+ parseopts(char *cp, struct exportent *ep, int warn, int *had_subtree_opt_ptr)
+ {
+-	int	had_subtree_opt = 0;
++	int	had_subtree_opt = 1;
+ 	char 	*flname = efname?efname:"command line";
+ 	int	flline = efp?efp->x_line:0;
+ 	unsigned int active = 0;

--- a/nfs-utils/SOURCES/nfs-utils-1.2.1-statdpath-man.patch
+++ b/nfs-utils/SOURCES/nfs-utils-1.2.1-statdpath-man.patch
@@ -1,0 +1,58 @@
+diff -up nfs-utils-1.2.8/utils/statd/sm-notify.man.orig nfs-utils-1.2.8/utils/statd/sm-notify.man
+--- nfs-utils-1.2.8/utils/statd/sm-notify.man.orig	2013-04-22 12:47:20.000000000 -0400
++++ nfs-utils-1.2.8/utils/statd/sm-notify.man	2013-09-18 15:32:01.511494000 -0400
+@@ -184,7 +184,7 @@ where NSM state information resides.
+ If this option is not specified,
+ .B sm-notify
+ uses
+-.I /var/lib/nfs
++.I /var/lib/nfs/statd
+ by default.
+ .IP
+ After starting,
+@@ -285,13 +285,13 @@ Currently, the
+ command supports sending notification only via datagram transport protocols.
+ .SH FILES
+ .TP 2.5i
+-.I /var/lib/nfs/sm
++.I /var/lib/nfs/statd/sm
+ directory containing monitor list
+ .TP 2.5i
+-.I /var/lib/nfs/sm.bak
++.I /var/lib/nfs/statd/sm.bak
+ directory containing notify list
+ .TP 2.5i
+-.I /var/lib/nfs/state
++.I /var/lib/nfs/statd/state
+ NSM state number for this host
+ .TP 2.5i
+ .I /proc/sys/fs/nfs/nsm_local_state
+diff -up nfs-utils-1.2.8/utils/statd/statd.man.orig nfs-utils-1.2.8/utils/statd/statd.man
+--- nfs-utils-1.2.8/utils/statd/statd.man.orig	2013-04-22 12:47:20.000000000 -0400
++++ nfs-utils-1.2.8/utils/statd/statd.man	2013-09-18 15:32:01.520491000 -0400
+@@ -233,7 +233,7 @@ where NSM state information resides.
+ If this option is not specified,
+ .B rpc.statd
+ uses
+-.I /var/lib/nfs
++.I /var/lib/nfs/statd
+ by default.
+ .IP
+ After starting,
+@@ -357,13 +357,13 @@ As long as at least one network transpor
+ will operate.
+ .SH FILES
+ .TP 2.5i
+-.I /var/lib/nfs/sm
++.I /var/lib/nfs/statd/sm
+ directory containing monitor list
+ .TP 2.5i
+-.I /var/lib/nfs/sm.bak
++.I /var/lib/nfs/statd/sm.bak
+ directory containing notify list
+ .TP 2.5i
+-.I /var/lib/nfs/state
++.I /var/lib/nfs/statd/state
+ NSM state number for this host
+ .TP 2.5i
+ .I /var/run/run.statd.pid

--- a/nfs-utils/SOURCES/nfs-utils-1.2.3-sm-notify-res_init.patch
+++ b/nfs-utils/SOURCES/nfs-utils-1.2.3-sm-notify-res_init.patch
@@ -1,0 +1,21 @@
+diff -up nfs-utils-1.2.8/utils/statd/sm-notify.c.orig nfs-utils-1.2.8/utils/statd/sm-notify.c
+--- nfs-utils-1.2.8/utils/statd/sm-notify.c.orig	2013-04-22 12:47:20.000000000 -0400
++++ nfs-utils-1.2.8/utils/statd/sm-notify.c	2013-09-18 15:36:42.373803000 -0400
+@@ -28,6 +28,9 @@
+ #include <netdb.h>
+ #include <errno.h>
+ #include <grp.h>
++#include <netinet/in.h>
++#include <arpa/nameser.h>
++#include <resolv.h>
+ 
+ #include "sockaddr.h"
+ #include "xlog.h"
+@@ -85,6 +88,7 @@ smn_lookup(const char *name)
+ 	};
+ 	int error;
+ 
++	res_init();
+ 	error = getaddrinfo(name, NULL, &hint, &ai);
+ 	if (error != 0) {
+ 		xlog(D_GENERAL, "getaddrinfo(3): %s", gai_strerror(error));

--- a/nfs-utils/SOURCES/nfs-utils-1.2.5-idmap-errmsg.patch
+++ b/nfs-utils/SOURCES/nfs-utils-1.2.5-idmap-errmsg.patch
@@ -1,0 +1,12 @@
+diff -up nfs-utils-1.3.3/utils/nfsidmap/nfsidmap.c.orig nfs-utils-1.3.3/utils/nfsidmap/nfsidmap.c
+--- nfs-utils-1.3.3/utils/nfsidmap/nfsidmap.c.orig	2016-03-16 12:29:29.054788094 -0400
++++ nfs-utils-1.3.3/utils/nfsidmap/nfsidmap.c	2016-03-16 12:31:58.234450259 -0400
+@@ -430,7 +430,7 @@ int main(int argc, char **argv)
+ 
+ 	xlog_stderr(verbose);
+ 	if ((argc - optind) != 2) {
+-		xlog_warn("Bad arg count. Check /etc/request-key.conf");
++		xlog_err("Bad arg count. Check /etc/request-key.d/request-key.conf");
+ 		xlog_warn(usage, progname);
+ 		return EXIT_FAILURE;
+ 	}

--- a/nfs-utils/SOURCES/nfs-utils-1.3.2-systemd-gssargs.patch
+++ b/nfs-utils/SOURCES/nfs-utils-1.3.2-systemd-gssargs.patch
@@ -1,0 +1,9 @@
+diff -up nfs-utils-1.3.4/systemd/rpc-gssd.service.in.orig nfs-utils-1.3.4/systemd/rpc-gssd.service.in
+--- nfs-utils-1.3.4/systemd/rpc-gssd.service.in.orig	2016-08-25 07:50:22.502919854 -0400
++++ nfs-utils-1.3.4/systemd/rpc-gssd.service.in	2016-08-25 07:53:42.807160300 -0400
+@@ -16,4 +16,4 @@ After=nfs-config.service
+ EnvironmentFile=-/run/sysconfig/nfs-utils
+ 
+ Type=forking
+-ExecStart=/usr/sbin/rpc.gssd $GSSDARGS
++ExecStart=/usr/sbin/rpc.gssd $RPCSVCGSSDARGS

--- a/nfs-utils/SOURCES/nfs-utils-1.3.5-rc2.patch
+++ b/nfs-utils/SOURCES/nfs-utils-1.3.5-rc2.patch
@@ -1,0 +1,583 @@
+diff --git a/.gitignore b/.gitignore
+index 5164637..126d12c 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -69,6 +69,9 @@ tests/nsm_client/nlm_sm_inter_clnt.c
+ tests/nsm_client/nlm_sm_inter_svc.c
+ tests/nsm_client/nlm_sm_inter_xdr.c
+ utils/nfsidmap/nfsidmap
++systemd/nfs-server-generator
++systemd/nfs-config.service
++systemd/rpc-gssd.service
+ # cscope database files
+ cscope.*
+ # generic editor backup et al
+diff --git a/configure.ac b/configure.ac
+index 1daf5b8..d60f3a2 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -511,8 +511,20 @@ AC_SUBST([AM_CFLAGS], ["$my_am_cflags"])
+ # Make sure that $ACLOCAL_FLAGS are used during a rebuild
+ AC_SUBST([ACLOCAL_AMFLAGS], ["-I $ac_macro_dir \$(ACLOCAL_FLAGS)"])
+ 
++# make libexecdir available for substituion in config files
++# 2 "evals" needed late to expand variable names.
++AC_SUBST([_libexecdir])
++AC_CONFIG_COMMANDS_PRE([eval eval _libexecdir=$libexecdir])
++
++# make _sysconfdir available for substituion in config files
++# 2 "evals" needed late to expand variable names.
++AC_SUBST([_sysconfdir])
++AC_CONFIG_COMMANDS_PRE([eval eval _sysconfdir=$sysconfdir])
++
+ AC_CONFIG_FILES([
+ 	Makefile
++	systemd/nfs-config.service
++	systemd/rpc-gssd.service
+ 	linux-nfs/Makefile
+ 	support/Makefile
+ 	support/export/Makefile
+diff --git a/support/export/export.c b/support/export/export.c
+index e1bebce..0b8a858 100644
+--- a/support/export/export.c
++++ b/support/export/export.c
+@@ -15,6 +15,8 @@
+ #include <sys/param.h>
+ #include <netinet/in.h>
+ #include <stdlib.h>
++#include <dirent.h>
++#include <errno.h>
+ #include "xmalloc.h"
+ #include "nfslib.h"
+ #include "exportfs.h"
+@@ -96,6 +98,69 @@ export_read(char *fname)
+ }
+ 
+ /**
++ * export_d_read - read entries from /etc/exports.
++ * @fname: name of directory to read from
++ *
++ * Returns number of read entries.
++ * Based on mnt_table_parse_dir() in
++ *  util-linux-ng/shlibs/mount/src/tab_parse.c
++ */
++int
++export_d_read(const char *dname)
++{
++	int n = 0, i;
++	struct dirent **namelist = NULL;
++	int volumes = 0;
++
++
++	n = scandir(dname, &namelist, NULL, versionsort);
++	if (n < 0) {
++		if (errno == ENOENT)
++			/* Silently return */
++			return volumes;
++		xlog(L_NOTICE, "scandir %s: %s", dname, strerror(errno));
++	} else if (n == 0)
++		return volumes;
++
++	for (i = 0; i < n; i++) {
++		struct dirent *d = namelist[i];
++		size_t namesz;
++		char fname[PATH_MAX + 1];
++		int fname_len;
++
++
++		if (d->d_type != DT_UNKNOWN
++		    && d->d_type != DT_REG
++		    && d->d_type != DT_LNK)
++			continue;
++		if (*d->d_name == '.')
++			continue;
++
++#define _EXT_EXPORT_SIZ   (sizeof(_EXT_EXPORT) - 1)
++		namesz = strlen(d->d_name);
++		if (!namesz
++		    || namesz < _EXT_EXPORT_SIZ + 1
++		    || strcmp(d->d_name + (namesz - _EXT_EXPORT_SIZ),
++			      _EXT_EXPORT))
++			continue;
++
++		fname_len = snprintf(fname, PATH_MAX +1, "%s/%s", dname, d->d_name);
++		if (fname_len > PATH_MAX) {
++			xlog(L_WARNING, "Too long file name: %s in %s", d->d_name, dname);
++			continue;
++		}
++
++		volumes += export_read(fname);
++	}
++
++	for (i = 0; i < n; i++)
++		free(namelist[i]);
++	free(namelist);
++
++	return volumes;
++}
++
++/**
+  * export_create - create an in-core nfs_export record from an export entry
+  * @xep: export entry to lookup
+  * @canonical: if set, e_hostname is known to be canonical DNS name
+diff --git a/support/include/exportfs.h b/support/include/exportfs.h
+index 4cac203..f033329 100644
+--- a/support/include/exportfs.h
++++ b/support/include/exportfs.h
+@@ -135,6 +135,7 @@ int 				client_member(const char *client,
+ 						const char *name);
+ 
+ int				export_read(char *fname);
++int				export_d_read(const char *dname);
+ void				export_reset(nfs_export *);
+ nfs_export *			export_lookup(char *hname, char *path, int caconical);
+ nfs_export *			export_find(const struct addrinfo *ai,
+diff --git a/systemd/Makefile.am b/systemd/Makefile.am
+index 03f96e9..49c9b8d 100644
+--- a/systemd/Makefile.am
++++ b/systemd/Makefile.am
+@@ -39,8 +39,16 @@ endif
+ EXTRA_DIST = $(unit_files)
+ 
+ unit_dir = /usr/lib/systemd/system
++generator_dir = /usr/lib/systemd/system-generators
++
++EXTRA_PROGRAMS	= nfs-server-generator
++genexecdir = $(generator_dir)
++nfs_server_generator_LDADD = ../support/export/libexport.a \
++			     ../support/nfs/libnfs.a \
++			     ../support/misc/libmisc.a
+ 
+ if INSTALL_SYSTEMD
++genexec_PROGRAMS = nfs-server-generator
+ install-data-hook: $(unit_files)
+ 	mkdir -p $(DESTDIR)/$(unitdir)
+ 	cp $(unit_files) $(DESTDIR)/$(unitdir)
+diff --git a/systemd/nfs-config.service b/systemd/nfs-config.service
+deleted file mode 100644
+index bd69e84..0000000
+--- a/systemd/nfs-config.service
++++ /dev/null
+@@ -1,13 +0,0 @@
+-[Unit]
+-Description=Preprocess NFS configuration
+-After=local-fs.target
+-DefaultDependencies=no
+-
+-[Service]
+-Type=oneshot
+-# This service needs to run any time any nfs service
+-# is started, so changes to local config files get
+-# incorporated.  Having "RemainAfterExit=no" (the default)
+-# ensures this happens.
+-RemainAfterExit=no
+-ExecStart=/usr/libexec/nfs-utils/nfs-utils_env.sh
+diff --git a/systemd/nfs-config.service.in b/systemd/nfs-config.service.in
+new file mode 100644
+index 0000000..e89dc54
+--- /dev/null
++++ b/systemd/nfs-config.service.in
+@@ -0,0 +1,13 @@
++[Unit]
++Description=Preprocess NFS configuration
++After=local-fs.target
++DefaultDependencies=no
++
++[Service]
++Type=oneshot
++# This service needs to run any time any nfs service
++# is started, so changes to local config files get
++# incorporated.  Having "RemainAfterExit=no" (the default)
++# ensures this happens.
++RemainAfterExit=no
++ExecStart=@_libexecdir@/nfs-utils/nfs-utils_env.sh
+diff --git a/systemd/nfs-server-generator.c b/systemd/nfs-server-generator.c
+new file mode 100644
+index 0000000..f47718e
+--- /dev/null
++++ b/systemd/nfs-server-generator.c
+@@ -0,0 +1,150 @@
++/*
++ * nfs-server-generator:
++ *   systemd generator to create ordering dependencies between
++ *   nfs-server and various filesystem mounts
++ *
++ * 1/ nfs-server should start Before any 'nfs' mountpoints are
++ *    mounted, in case they are loop-back mounts.  This ordering is particularly
++ *    important for the shutdown side, so the nfs-server is stopped
++ *    after the filesystems are unmounted.
++ * 2/ nfs-server should start After all exported filesystems are mounted
++ *    so there is no risk of exporting the underlying directory.
++ *    This is particularly important for _net mounts which
++ *    are not caught by "local-fs.target".
++ */
++
++#ifdef HAVE_CONFIG_H
++#include <config.h>
++#endif
++
++#include <sys/stat.h>
++#include <sys/types.h>
++#include <unistd.h>
++#include <stdlib.h>
++#include <string.h>
++#include <ctype.h>
++#include <stdio.h>
++#include <mntent.h>
++
++#include "misc.h"
++#include "nfslib.h"
++#include "exportfs.h"
++
++/* A simple "set of strings" to remove duplicates
++ * found in /etc/exports
++ */
++struct list {
++	struct list *next;
++	char *name;
++};
++static int is_unique(struct list **lp, char *path)
++{
++	struct list *l = *lp;
++
++	while (l) {
++		if (strcmp(l->name, path) == 0)
++			return 0;
++		l = l->next;
++	}
++	l = malloc(sizeof(*l));
++	if (l == NULL)
++		return 0;
++	l->name = path;
++	l->next = *lp;
++	*lp = l;
++	return 1;
++}
++
++/* We need to convert a path name to a systemd unit
++ * name.  This requires some translation ('/' -> '-')
++ * and some escaping.
++ */
++static void systemd_escape(FILE *f, char *path)
++{
++	while (*path == '/')
++		path++;
++	if (!*path) {
++		/* "/" becomes "-", otherwise leading "/" is ignored */
++		fputs("-", f);
++		return;
++	}
++	while (*path) {
++		char c = *path++;
++
++		if (c == '/') {
++			/* multiple non-trailing slashes become '-' */
++			while (*path == '/')
++				path++;
++			if (*path)
++				fputs("-", f);
++		} else if (isalnum(c) || c == ':' || c == '.')
++			fputc(c, f);
++		else
++			fprintf(f, "\\x%02x", c & 0xff);
++	}
++}
++
++int main(int argc, char *argv[])
++{
++	char		*path;
++	char		dirbase[] = "/nfs-server.service.d";
++	char		filebase[] = "/order-with-mounts.conf";
++	nfs_export	*exp;
++	int		i;
++	struct list	*list = NULL;
++	FILE		*f, *fstab;
++	struct mntent	*mnt;
++
++	if (argc != 4 || argv[1][0] != '/') {
++		fprintf(stderr, "nfs-server-generator: create systemd dependencies for nfs-server\n");
++		fprintf(stderr, "Usage: normal-dir early-dir late-dir\n");
++		exit(1);
++	}
++
++	path = malloc(strlen(argv[1]) + sizeof(dirbase) + sizeof(filebase));
++	if (!path)
++		exit(2);
++	if (export_read(_PATH_EXPORTS) +
++	    export_d_read(_PATH_EXPORTS_D) == 0)
++		/* Nothing is exported, so nothing to do */
++		exit(0);
++
++	strcat(strcpy(path, argv[1]), dirbase);
++	mkdir(path, 0755);
++	strcat(path, filebase);
++	f = fopen(path, "w");
++	if (!f)
++		exit(1);
++	fprintf(f, "# Automatically generated by nfs-server-generator\n\n[Unit]\n");
++
++	for (i = 0; i < MCL_MAXTYPES; i++) {
++		for (exp = exportlist[i].p_head; exp; exp = exp->m_next) {
++			if (!is_unique(&list, exp->m_export.e_path))
++				continue;
++			if (strchr(exp->m_export.e_path, ' '))
++				fprintf(f, "RequiresMountsFor=\"%s\"\n",
++					exp->m_export.e_path);
++			else
++				fprintf(f, "RequiresMountsFor=%s\n",
++					exp->m_export.e_path);
++		}
++	}
++
++	fstab = setmntent("/etc/fstab", "r");
++	if (!fstab)
++		exit(1);
++
++	while ((mnt = getmntent(fstab)) != NULL) {
++		if (strcmp(mnt->mnt_type, "nfs") != 0 &&
++		    strcmp(mnt->mnt_type, "nfs4") != 0)
++			continue;
++		fprintf(f, "Before= ");
++		systemd_escape(f, mnt->mnt_dir);
++		fprintf(f, ".mount\n");
++	}
++
++	fclose(fstab);
++	fclose(f);
++
++	exit(0);
++}
+diff --git a/systemd/nfs-server.service b/systemd/nfs-server.service
+index 2ccdc63..196c818 100644
+--- a/systemd/nfs-server.service
++++ b/systemd/nfs-server.service
+@@ -16,9 +16,6 @@ Before= rpc-statd-notify.service
+ Wants=auth-rpcgss-module.service
+ After=rpc-gssd.service gssproxy.service rpc-svcgssd.service
+ 
+-# start/stop server before/after client
+-Before=remote-fs-pre.target
+-
+ Wants=nfs-config.service
+ After=nfs-config.service
+ 
+diff --git a/systemd/rpc-gssd.service b/systemd/rpc-gssd.service
+deleted file mode 100644
+index d4a3819..0000000
+--- a/systemd/rpc-gssd.service
++++ /dev/null
+@@ -1,19 +0,0 @@
+-[Unit]
+-Description=RPC security service for NFS client and server
+-DefaultDependencies=no
+-Conflicts=umount.target
+-Requires=var-lib-nfs-rpc_pipefs.mount
+-After=var-lib-nfs-rpc_pipefs.mount
+-
+-ConditionPathExists=/etc/krb5.keytab
+-
+-PartOf=nfs-utils.service
+-
+-Wants=nfs-config.service
+-After=nfs-config.service
+-
+-[Service]
+-EnvironmentFile=-/run/sysconfig/nfs-utils
+-
+-Type=forking
+-ExecStart=/usr/sbin/rpc.gssd $GSSDARGS
+diff --git a/systemd/rpc-gssd.service.in b/systemd/rpc-gssd.service.in
+new file mode 100644
+index 0000000..1a7911c
+--- /dev/null
++++ b/systemd/rpc-gssd.service.in
+@@ -0,0 +1,19 @@
++[Unit]
++Description=RPC security service for NFS client and server
++DefaultDependencies=no
++Conflicts=umount.target
++Requires=var-lib-nfs-rpc_pipefs.mount
++After=var-lib-nfs-rpc_pipefs.mount
++
++ConditionPathExists=@_sysconfdir@/krb5.keytab
++
++PartOf=nfs-utils.service
++
++Wants=nfs-config.service
++After=nfs-config.service
++
++[Service]
++EnvironmentFile=-/run/sysconfig/nfs-utils
++
++Type=forking
++ExecStart=/usr/sbin/rpc.gssd $GSSDARGS
+diff --git a/utils/exportfs/exportfs.c b/utils/exportfs/exportfs.c
+index a00b5ea..4ac2c15 100644
+--- a/utils/exportfs/exportfs.c
++++ b/utils/exportfs/exportfs.c
+@@ -26,7 +26,6 @@
+ #include <fcntl.h>
+ #include <netdb.h>
+ #include <errno.h>
+-#include <dirent.h>
+ #include <limits.h>
+ #include <time.h>
+ 
+@@ -47,7 +46,6 @@ static void	error(nfs_export *exp, int err);
+ static void	usage(const char *progname, int n);
+ static void	validate_export(nfs_export *exp);
+ static int	matchhostname(const char *hostname1, const char *hostname2);
+-static int	export_d_read(const char *dname);
+ static void grab_lockfile(void);
+ static void release_lockfile(void);
+ 
+@@ -700,63 +698,6 @@ out:
+ 	return result;
+ }
+ 
+-/* Based on mnt_table_parse_dir() in
+-   util-linux-ng/shlibs/mount/src/tab_parse.c */
+-static int
+-export_d_read(const char *dname)
+-{
+-	int n = 0, i;
+-	struct dirent **namelist = NULL;
+-	int volumes = 0;
+-
+-
+-	n = scandir(dname, &namelist, NULL, versionsort);
+-	if (n < 0) {
+-		if (errno == ENOENT)
+-			/* Silently return */
+-			return volumes;
+-		xlog(L_NOTICE, "scandir %s: %s", dname, strerror(errno));
+-	} else if (n == 0)
+-		return volumes;
+-
+-	for (i = 0; i < n; i++) {
+-		struct dirent *d = namelist[i];
+-		size_t namesz;
+-		char fname[PATH_MAX + 1];
+-		int fname_len;
+-
+-
+-		if (d->d_type != DT_UNKNOWN
+-		    && d->d_type != DT_REG
+-		    && d->d_type != DT_LNK)
+-			continue;
+-		if (*d->d_name == '.')
+-			continue;
+-
+-#define _EXT_EXPORT_SIZ   (sizeof(_EXT_EXPORT) - 1)
+-		namesz = strlen(d->d_name);
+-		if (!namesz
+-		    || namesz < _EXT_EXPORT_SIZ + 1
+-		    || strcmp(d->d_name + (namesz - _EXT_EXPORT_SIZ),
+-			      _EXT_EXPORT))
+-			continue;
+-
+-		fname_len = snprintf(fname, PATH_MAX +1, "%s/%s", dname, d->d_name);
+-		if (fname_len > PATH_MAX) {
+-			xlog(L_WARNING, "Too long file name: %s in %s", d->d_name, dname);
+-			continue;
+-		}
+-
+-		volumes += export_read(fname);
+-	}
+-
+-	for (i = 0; i < n; i++)
+-		free(namelist[i]);
+-	free(namelist);
+-
+-	return volumes;
+-}
+-
+ static char
+ dumpopt(char c, char *fmt, ...)
+ {
+diff --git a/utils/idmapd/idmapd.man b/utils/idmapd/idmapd.man
+index b9200c7..d4ab894 100644
+--- a/utils/idmapd/idmapd.man
++++ b/utils/idmapd/idmapd.man
+@@ -23,6 +23,29 @@ is the NFSv4 ID <-> name mapping daemon.  It provides functionality to
+ the NFSv4 kernel client and server, to which it communicates via
+ upcalls, by translating user and group IDs to names, and vice versa.
+ .Pp
++The system derives the
++.I user
++part of the string by performing a password or group lookup.
++The lookup mechanism is configured in
++.Pa /etc/idmapd.conf
++.Pp
++By default, the
++.I domain
++part of the string is the system's DNS domain name.
++It can also be specified in
++.Pa /etc/idmapd.conf
++if the system is multi-homed,
++or if the system's DNS domain name does
++not match the name of the system's Kerberos realm.
++.Pp
++When the domain is not specified in /etc/idmapd.conf
++the local DNS server will be queried for the 
++.Sy _nfsv4idmapdomain 
++text record. If the record exists
++that will be used as the domain. When the record
++does not exist, the domain part of the DNS domain
++will used. 
++.Pp
+ Note that on more recent kernels only the NFSv4 server uses
+ .Nm .
+ The NFSv4 client instead uses
+diff --git a/utils/mount/stropts.c b/utils/mount/stropts.c
+index 9de6794..d5dfb5e 100644
+--- a/utils/mount/stropts.c
++++ b/utils/mount/stropts.c
+@@ -948,6 +948,7 @@ static int nfs_is_permanent_error(int error)
+ 	case ETIMEDOUT:
+ 	case ECONNREFUSED:
+ 	case EHOSTUNREACH:
++	case EOPNOTSUPP:	/* aka RPC_PROGNOTREGISTERED */
+ 	case EAGAIN:
+ 		return 0;	/* temporary */
+ 	default:
+@@ -1019,8 +1020,7 @@ static int nfsmount_parent(struct nfsmount_info *mi)
+ 	if (nfs_try_mount(mi))
+ 		return EX_SUCCESS;
+ 
+-	/* retry background mounts when the server is not up */
+-	if (nfs_is_permanent_error(errno) && errno != EOPNOTSUPP) {
++	if (nfs_is_permanent_error(errno)) {
+ 		mount_error(mi->spec, mi->node, errno);
+ 		return EX_FAIL;
+ 	}
+@@ -1055,8 +1055,7 @@ static int nfsmount_child(struct nfsmount_info *mi)
+ 		if (nfs_try_mount(mi))
+ 			return EX_SUCCESS;
+ 
+-		/* retry background mounts when the server is not up */
+-		if (nfs_is_permanent_error(errno) && errno != EOPNOTSUPP)
++		if (nfs_is_permanent_error(errno))
+ 			break;
+ 
+ 		if (time(NULL) > timeout)
+diff --git a/utils/nfsidmap/nfsidmap.man b/utils/nfsidmap/nfsidmap.man
+index 2f17cf2..2af16f3 100644
+--- a/utils/nfsidmap/nfsidmap.man
++++ b/utils/nfsidmap/nfsidmap.man
+@@ -39,6 +39,15 @@ if the system is multi-homed,
+ or if the system's DNS domain name does
+ not match the name of the system's Kerberos realm.
+ .PP
++When the domain is not specified in 
++.I /etc/idmapd.conf
++the local DNS server will be queried for the 
++.I _nfsv4idmapdomain 
++text record. If the record exists
++that will be used as the domain. When the record
++does not exist, the domain part of the DNS domain
++will used. 
++.PP
+ The
+ .I /usr/sbin/nfsidmap
+ program performs translations on behalf of the kernel.

--- a/nfs-utils/SOURCES/nfs-utils_env.sh
+++ b/nfs-utils/SOURCES/nfs-utils_env.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+#
+# Extract configuration from /etc/sysconfig/nfs and write
+# environment variables to /run/sysconfig/nfs-utils to be 
+# used by systemd nfs-config service
+#
+
+nfs_config=/etc/sysconfig/nfs
+if test -r $nfs_config; then
+    . $nfs_config
+fi
+
+[ -n "$LOCKDARG" ] && /sbin/modprobe lockd $LOCKDARG
+if [ -n "$LOCKD_TCPPORT" -o -n "$LOCKD_UDPPORT" ]; then
+    [ -z "$LOCKDARG" ] && /sbin/modprobe lockd $LOCKDARG
+    [ -n "$LOCKD_TCPPORT" ] && \
+        /sbin/sysctl -w fs.nfs.nlm_tcpport=$LOCKD_TCPPORT >/dev/null 2>&1
+    [ -n "$LOCKD_UDPPORT" ] && \
+        /sbin/sysctl -w fs.nfs.nlm_udpport=$LOCKD_UDPPORT >/dev/null 2>&1
+fi
+
+if [ -n "$NFSD_V4_GRACE" ]; then
+    grace="-G $NFSD_V4_GRACE"
+fi
+
+if [ -n "$NFSD_V4_LEASE" ]; then
+    lease="-L $NFSD_V4_LEASE"
+fi
+
+if [ -n "$RPCNFSDCOUNT" ]; then
+    nfsds=$RPCNFSDCOUNT
+else
+    nfsds=8
+fi
+
+if [ -n "$RPCNFSDARGS" ]; then
+    nfsdargs="$RPCNFSDARGS $grace $lease $nfsds"
+else
+    nfsdargs="$grace $lease $nfsds"
+fi
+
+mkdir -p /run/sysconfig
+{
+echo RPCNFSDARGS=\"$nfsdargs\"
+echo RPCMOUNTDARGS=\"$RPCMOUNTDOPTS\"
+echo STATDARGS=\"$STATDARG\"
+echo SMNOTIFYARGS=\"$SMNOTIFYARGS\"
+echo RPCIDMAPDARGS=\"$RPCIDMAPDARGS\"
+echo RPCGSSDARGS=\"$RPCGSSDARGS\"
+echo RPCSVCGSSDARGS=\"$RPCSVCGSSDARGS\"
+echo BLKMAPDARGS=\"$BLKMAPDARGS\"
+echo GSS_USE_PROXY=\"$GSS_USE_PROXY\"
+} > /run/sysconfig/nfs-utils

--- a/nfs-utils/SOURCES/nfs.sysconfig
+++ b/nfs-utils/SOURCES/nfs.sysconfig
@@ -1,0 +1,42 @@
+#
+# Optional arguments passed to in-kernel lockd 
+#LOCKDARG=
+# TCP port rpc.lockd should listen on.
+#LOCKD_TCPPORT=32803
+# UDP port rpc.lockd should listen on.
+#LOCKD_UDPPORT=32769
+#
+# Optional arguments passed to rpc.nfsd. See rpc.nfsd(8)
+RPCNFSDARGS=""
+# Number of nfs server processes to be started.
+# The default is 8. 
+# RPCNFSDCOUNT=16
+#   
+# Set V4 grace period in seconds
+#NFSD_V4_GRACE=90
+#
+# Set V4 lease period in seconds
+#NFSD_V4_LEASE=90
+#
+# Optional arguments passed to rpc.mountd. See rpc.mountd(8)
+RPCMOUNTDOPTS=""
+#
+# Optional arguments passed to rpc.statd. See rpc.statd(8)
+STATDARG=""
+# Optional arguments passed to sm-notify. See sm-notify(8)
+SMNOTIFYARGS=""
+#
+#
+# Optional arguments passed to rpc.idmapd. See rpc.idmapd(8)
+RPCIDMAPDARGS=""
+#
+# Optional arguments passed to rpc.gssd. See rpc.gssd(8)
+RPCGSSDARGS=""
+# Enable usage of gssproxy. See gssproxy-mech(8).
+GSS_USE_PROXY="yes"
+#
+# Optional arguments passed to rpc.svcgssd. See rpc.svcgssd(8)
+RPCSVCGSSDARGS=""
+#
+# Optional arguments passed to blkmapd. See blkmapd(8)
+BLKMAPDARGS=""

--- a/nfs-utils/nfs-utils.spec
+++ b/nfs-utils/nfs-utils.spec
@@ -1,0 +1,342 @@
+###############################################################################
+
+%define _posixroot        /
+%define _root             /root
+%define _bin              /bin
+%define _sbin             /sbin
+%define _srv              /srv
+%define _home             /home
+%define _lib32            %{_posixroot}lib
+%define _lib64            %{_posixroot}lib64
+%define _libdir32         %{_prefix}%{_lib32}
+%define _libdir64         %{_prefix}%{_lib64}
+%define _logdir           %{_localstatedir}/log
+%define _rundir           %{_localstatedir}/run
+%define _lockdir          %{_localstatedir}/lock/subsys
+%define _cachedir         %{_localstatedir}/cache
+%define _spooldir         %{_localstatedir}/spool
+%define _crondir          %{_sysconfdir}/cron.d
+%define _loc_prefix       %{_prefix}/local
+%define _loc_exec_prefix  %{_loc_prefix}
+%define _loc_bindir       %{_loc_exec_prefix}/bin
+%define _loc_libdir       %{_loc_exec_prefix}/%{_lib}
+%define _loc_libdir32     %{_loc_exec_prefix}/%{_lib32}
+%define _loc_libdir64     %{_loc_exec_prefix}/%{_lib64}
+%define _loc_libexecdir   %{_loc_exec_prefix}/libexec
+%define _loc_sbindir      %{_loc_exec_prefix}/sbin
+%define _loc_bindir       %{_loc_exec_prefix}/bin
+%define _loc_datarootdir  %{_loc_prefix}/share
+%define _loc_includedir   %{_loc_prefix}/include
+%define _loc_mandir       %{_loc_datarootdir}/man
+%define _rpmstatedir      %{_sharedstatedir}/rpm-state
+%define _pkgconfigdir     %{_libdir}/pkgconfig
+
+%define __ldconfig        %{_sbin}/ldconfig
+%define __service         %{_sbin}/service
+%define __touch           %{_bin}/touch
+%define __chkconfig       %{_sbin}/chkconfig
+%define __updalt          %{_sbindir}/update-alternatives
+%define __useradd         %{_sbindir}/useradd
+%define __usermod         %{_sbindir}/usermod
+%define __groupadd        %{_sbindir}/groupadd
+%define __groupmod        %{_sbindir}/groupmod
+%define __getent          %{_bindir}/getent
+%define __systemctl       %{_bindir}/systemctl
+
+%define _statdpath        %{_sharedstatedir}/nfs/statd
+%define _pkgdir           %{_prefix}/lib/systemd
+
+%define all_32bit_archs   i386 i486 i586 i686 athlon ppc sparcv9
+
+%define rpcuser_name      rpcuser
+%define rpcuser_group     rpcuser
+%define rpcuser_gid       29
+%define rpcuser_uid       29
+%define rpcuser_home      %{_sharedstatedir}/nfs
+
+# Using the 16-bit value of -2 for the nfsnobody uid and gid
+%define nfsnobody_name    nfsnobody
+%define nfsnobody_group   nfsnobody
+%define nfsnobody_uid     65534
+%define nfsnobody_gid     65534
+%define nfsnobody_home    %{_sharedstatedir}/nfs
+
+###############################################################################
+
+Summary:              NFS utilities and supporting clients and daemons for the kernel NFS server
+Name:                 nfs-utils
+Version:              1.3.4
+Epoch:                1
+Release:              0%{?dist}
+License:              MIT and GPLv2 and GPLv2+ and BSD
+Group:                System Environment/Daemons
+URL:                  http://sourceforge.net/projects/nfs
+
+Source0:              https://www.kernel.org/pub/linux/utils/%{name}/%{version}/%{name}-%{version}.tar.xz
+Source1:              id_resolver.conf
+Source2:              nfs.sysconfig
+Source3:              nfs-utils_env.sh
+Source4:              lockd.conf
+
+Patch001:             %{name}-1.3.5-rc2.patch
+Patch100:             %{name}-1.2.1-statdpath-man.patch
+Patch101:             %{name}-1.2.1-exp-subtree-warn-off.patch
+Patch102:             %{name}-1.2.3-sm-notify-res_init.patch
+Patch103:             %{name}-1.2.5-idmap-errmsg.patch
+Patch104:             %{name}-1.3.2-systemd-gssargs.patch
+
+BuildRoot:            %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+
+BuildRequires:        libevent-devel >= 2.0.22 libcap-devel
+BuildRequires:        libnfsidmap-devel libtirpc-devel libblkid-devel
+BuildRequires:        krb5-libs >= 1.4 autoconf >= 2.57 openldap-devel >= 2.2
+BuildRequires:        automake libtool gcc device-mapper-devel
+BuildRequires:        krb5-devel tcp_wrappers-devel libmount-devel
+BuildRequires:        sqlite-devel python-devel
+
+Requires:             rpcbind sed gawk sh-utils fileutils textutils grep
+Requires:             kmod keyutils quota libnfsidmap libevent >= 2.0.22
+Requires:             libtirpc >= 0.2.3-1 libblkid libcap libmount
+Requires:             gssproxy => 0.3.0-0
+
+Provides:             exportfs    = %{epoch}:%{version}-%{release}
+Provides:             nfsstat     = %{epoch}:%{version}-%{release}
+Provides:             showmount   = %{epoch}:%{version}-%{release}
+Provides:             rpcdebug    = %{epoch}:%{version}-%{release}
+Provides:             rpc.idmapd  = %{epoch}:%{version}-%{release}
+Provides:             rpc.mountd  = %{epoch}:%{version}-%{release}
+Provides:             rpc.nfsd    = %{epoch}:%{version}-%{release}
+Provides:             rpc.statd   = %{epoch}:%{version}-%{release}
+Provides:             rpc.gssd    = %{epoch}:%{version}-%{release}
+Provides:             mount.nfs   = %{epoch}:%{version}-%{release}
+Provides:             mount.nfs4  = %{epoch}:%{version}-%{release}
+Provides:             umount.nfs  = %{epoch}:%{version}-%{release}
+Provides:             umount.nfs4 = %{epoch}:%{version}-%{release}
+Provides:             sm-notify   = %{epoch}:%{version}-%{release}
+Provides:             start-statd = %{epoch}:%{version}-%{release}
+
+Requires(pre):        shadow-utils >= 4.0.3-25
+Requires(pre):        util-linux
+Requires(post):       systemd-units
+Requires(preun):      systemd-units
+Requires(postun):     systemd-units
+
+###############################################################################
+
+%description
+The nfs-utils package provides a daemon for the kernel NFS server and
+related tools, which provides a much higher level of performance than the
+traditional Linux NFS server used by most users.
+
+This package also contains the showmount program.  Showmount queries the
+mount daemon on a remote host for information about the NFS (Network File
+System) server on the remote host.  For example, showmount can display the
+clients which are mounted on that host.
+
+This package also contains the mount.nfs and umount.nfs program.
+
+###############################################################################
+
+%prep
+%setup -q
+
+%patch001 -p1
+%patch100 -p1
+%patch101 -p1
+%patch102 -p1
+%patch103 -p1
+%patch104 -p1
+
+%build
+%ifarch s390 s390x sparcv9 sparc64
+PIE="-fPIE"
+%else
+PIE="-fpie"
+%endif
+export PIE
+
+./autogen.sh
+
+CFLAGS="`echo $RPM_OPT_FLAGS $ARCH_OPT_FLAGS $PIE -D_FILE_OFFSET_BITS=64`"
+
+%configure \
+    CFLAGS="$CFLAGS" \
+    CPPFLAGS="$DEFINES" \
+    LDFLAGS="-pie" \
+    --enable-mountconfig \
+    --enable-ipv6 \
+    --with-statdpath=%{_statdpath} \
+    --enable-libmount-mount \
+    --with-systemd
+
+make %{?_smp_mflags} all
+
+%install
+rm -rf %{buildroot}/*
+
+install -d %{buildroot}%{_sbin}
+install -d %{buildroot}%{_sbindir}
+install -d %{buildroot}%{_libexecdir}/%{name}
+install -d %{buildroot}%{_pkgdir}/system
+install -d %{buildroot}%{_pkgdir}/system-generators
+install -d %{buildroot}%{_mandir}/man8
+install -d %{buildroot}%{_sysconfdir}/sysconfig
+install -d %{buildroot}%{_sysconfdir}/request-key.d
+install -d %{buildroot}%{_sysconfdir}/modprobe.d
+install -d %{buildroot}%{_sysconfdir}/exports.d
+install -d %{buildroot}/run/sysconfig
+install -d %{buildroot}%{_pkgdir}/scripts
+install -d %{buildroot}%{_sharedstatedir}/nfs/rpc_pipefs
+install -d %{buildroot}%{_sharedstatedir}/nfs/statd/sm
+install -d %{buildroot}%{_sharedstatedir}/nfs/statd/sm.bak
+install -d %{buildroot}%{_sharedstatedir}/nfs/v4recovery
+
+make DESTDIR=%{buildroot} install
+
+# rpc.svcgssd is no longer supported.
+rm -rf %{buildroot}%{_unitdir}/rpc-svcgssd.service
+
+install -pm 755 tools/rpcdebug/rpcdebug %{buildroot}%{_sbindir}
+install -pm 644 utils/mount/nfsmount.conf %{buildroot}%{_sysconfdir}
+install -pm 644 %{SOURCE1} %{buildroot}%{_sysconfdir}/request-key.d
+install -pm 644 %{SOURCE2} %{buildroot}%{_sysconfdir}/sysconfig/nfs
+install -pm 755 %{SOURCE3} %{buildroot}/usr/libexec/nfs-utils/nfs-utils_env.sh
+install -pm 644 %{SOURCE4} %{buildroot}%{_sysconfdir}/modprobe.d/lockd.conf
+
+# create symlinks for backward compatibility with an older versions nfs-utils
+pushd %{buildroot}%{_unitdir}
+    ln -s nfs-server.service nfs.service
+    ln -s rpc-gssd.service nfs-secure.service
+    ln -s nfs-idmapd.service  nfs-idmap.service
+    ln -s rpc-statd.service nfs-lock.service
+popd
+
+touch %{buildroot}%{_sharedstatedir}/nfs/rmtab
+
+mv %{buildroot}%{_sbindir}/rpc.statd %{buildroot}/sbin
+
+###############################################################################
+
+%clean
+rm -rf %{buildroot}/*
+
+%pre
+# move files so the running service will have this applied as well
+for x in gssd idmapd ; do
+    if [[ -f /var/lock/subsys/rpc.$x ]]; then
+        mv /var/lock/subsys/rpc.$x /var/lock/subsys/rpc$x
+    fi
+done
+
+# Create rpcuser gid as long as it does not already exist
+cat /etc/group | cut -d ':' -f 1 | grep --quiet %{rpcuser_group} 2>/dev/null
+if [ "$?" -eq 1 ]; then
+    %{__groupadd} -g %{rpcuser_gid} %{rpcuser_group} >/dev/null 2>&1 || :
+else
+    %{__groupmod} -g %{rpcuser_gid} %{rpcuser_group} >/dev/null 2>&1 || :
+fi
+
+# Create rpcuser uid as long as it does not already exist.
+cat /etc/passwd | cut -d ':' -f 1 | grep --quiet %{rpcuser_name} 2>/dev/null
+if [ "$?" -eq 1 ]; then
+    %{__useradd} -l -c "RPC Service User" -r -g %{rpcuser_uid} \
+      -s /sbin/nologin -u %{rpcuser_uid} \
+      -d %{rpcuser_home} %{rpcuser_name} >/dev/null 2>&1 || :
+else
+    %{__usermod} -u %{rpcuser_uid} -g %{rpcuser_uid} rpcuser >/dev/null 2>&1 || :
+fi
+
+# Create nfsnobody gid as long as it does not already exist
+cat /etc/group | cut -d ':' -f 1 | grep --quiet %{nfsnobody_group} 2>/dev/null
+if [ "$?" -eq 1 ]; then
+    %{__groupadd} -g %{nfsnobody_gid} %{nfsnobody_group} >/dev/null 2>&1 || :
+else
+    %{__groupmod} -g %{nfsnobody_gid} %{nfsnobody_group} >/dev/null 2>&1 || :
+fi
+
+# Create nfsnobody uid as long as it does not already exist.
+cat /etc/passwd | cut -d ':' -f 1 | grep --quiet %{nfsnobody_name} 2>/dev/null
+if [ $? -eq 1 ]; then
+    %{__useradd} -l -c "Anonymous NFS User" -r -g %{nfsnobody_uid} \
+      -s /sbin/nologin -u %{nfsnobody_uid} \
+      -d %{nfsnobody_home} %{nfsnobody_name} >/dev/null 2>&1 || :
+else
+    %{__usermod} -u %{nfsnobody_uid} -g %{nfsnobody_uid} %{nfsnobody_name} >/dev/null 2>&1 || :
+fi
+
+%post
+if [[ $1 -eq 1 ]] ; then
+    %{__systemctl} enable nfs-client.target >/dev/null 2>&1 || :
+    %{__systemctl} start nfs-client.target  >/dev/null 2>&1 || :
+fi
+%systemd_post nfs-config
+%systemd_post nfs-server
+
+# Make sure statd used the correct uid/gid.
+chown -R rpcuser:rpcuser %{rpcuser_home}/statd
+
+%preun
+if [[ $1 -eq 0 ]]; then
+    %systemd_preun nfs-client.target
+    %systemd_preun nfs-server.server
+
+    rm -rf /var/lib/nfs/statd /var/lib/nfs/v4recovery
+fi
+
+%postun
+%systemd_postun_with_restart nfs-client.target
+%systemd_postun_with_restart nfs-server
+
+%{__systemctl} --system daemon-reload >/dev/null 2>&1 || :
+
+###############################################################################
+
+%files
+%defattr(-,root,root,-)
+%config(noreplace) %{_sysconfdir}/sysconfig/nfs
+%config(noreplace) %{_sysconfdir}/nfsmount.conf
+%dir %{_sysconfdir}/exports.d
+%dir %{_sharedstatedir}/nfs/v4recovery
+%dir %{_sharedstatedir}/nfs/rpc_pipefs
+%dir %{_sharedstatedir}/nfs
+%dir %attr(700,rpcuser,rpcuser) %{_sharedstatedir}/nfs/statd
+%dir %attr(700,rpcuser,rpcuser) %{_sharedstatedir}/nfs/statd/sm
+%dir %attr(700,rpcuser,rpcuser) %{_sharedstatedir}/nfs/statd/sm.bak
+%ghost %attr(644,rpcuser,rpcuser) %{_statdpath}/state
+%config(noreplace) %{_sharedstatedir}/nfs/xtab
+%config(noreplace) %{_sharedstatedir}/nfs/etab
+%config(noreplace) %{_sharedstatedir}/nfs/rmtab
+%config(noreplace) %{_sysconfdir}/request-key.d/id_resolver.conf
+%config(noreplace) %{_sysconfdir}/modprobe.d/lockd.conf
+%doc linux-nfs/ChangeLog linux-nfs/KNOWNBUGS linux-nfs/NEW linux-nfs/README
+%doc linux-nfs/THANKS linux-nfs/TODO
+%{_sbin}/rpc.statd
+%{_sbin}/osd_login
+%{_sbin}/nfsdcltrack
+%{_sbindir}/exportfs
+%{_sbindir}/nfsstat
+%{_sbindir}/rpcdebug
+%{_sbindir}/rpc.mountd
+%{_sbindir}/rpc.nfsd
+%{_sbindir}/showmount
+%{_sbindir}/rpc.idmapd
+%{_sbindir}/rpc.gssd
+%{_sbindir}/sm-notify
+%{_sbindir}/start-statd
+%{_sbindir}/mountstats
+%{_sbindir}/nfsiostat
+%{_sbindir}/nfsidmap
+%{_sbindir}/blkmapd
+%{_mandir}/*/*
+%{_pkgdir}/*/*
+%attr(755,root,root) /usr/libexec/nfs-utils/nfs-utils_env.sh
+%attr(4755,root,root) /sbin/mount.nfs
+%{_sbin}/mount.nfs4
+%{_sbin}/umount.nfs
+%{_sbin}/umount.nfs4
+
+###############################################################################
+
+%changelog
+* Tue Aug 01 2017 Gleb Goncharov <ggoncharov@fun-box.ru> 1.3.4-0
+- Initial build.


### PR DESCRIPTION
I found out that nfs-utils which is placed in the official CentOS/RHEL repository requires `libevent-2.0` as a dependency. However, ESSENTIAL KAOS repo contains `libevent-2.0.22` so I unable to install nfs-utils because of this. Pay attention that `nfs-utils` is major component for NFS filesystems in Linux. 

I suppose that would be better to have a fresh version of `nfs-utils` with `libevent` support from this repository. @andyone what do you think, should we have a `nfs-utils` package for CentOS 6? Or is it enough to have version only for CentOS 7? I also have not tested it yet. I ask you to have a look and say your opinion.