### PR TITLE
Add ExecReload handler support to HAProxy systemd unit

### DIFF
--- a/haproxy-1.5/SOURCES/haproxy.service
+++ b/haproxy-1.5/SOURCES/haproxy.service
@@ -6,6 +6,9 @@ After=syslog.target network.target
 PIDFile=/var/run/haproxy.pid
 ExecStart=/etc/init.d/haproxy start
 ExecStop=/etc/init.d/haproxy stop
+ExecReload=/bin/kill -SIGUSR1 $MAINPID
+KillMode=mixed
+Restart=always
 
 [Install]
 WantedBy=multi-user.target

--- a/haproxy-1.6/SOURCES/haproxy.service
+++ b/haproxy-1.6/SOURCES/haproxy.service
@@ -6,6 +6,9 @@ After=syslog.target network.target
 PIDFile=/var/run/haproxy.pid
 ExecStart=/etc/init.d/haproxy start
 ExecStop=/etc/init.d/haproxy stop
+ExecReload=/bin/kill -SIGUSR1 $MAINPID
+KillMode=mixed
+Restart=always
 
 [Install]
 WantedBy=multi-user.target

--- a/haproxy-1.7/SOURCES/haproxy.service
+++ b/haproxy-1.7/SOURCES/haproxy.service
@@ -6,6 +6,9 @@ After=syslog.target network.target
 PIDFile=/var/run/haproxy.pid
 ExecStart=/etc/init.d/haproxy start
 ExecStop=/etc/init.d/haproxy stop
+ExecReload=/bin/kill -SIGUSR1 $MAINPID
+KillMode=mixed
+Restart=always
 
 [Install]
 WantedBy=multi-user.target

--- a/rbenv/SOURCES/rbenv-configure-sed.patch
+++ b/rbenv/SOURCES/rbenv-configure-sed.patch
@@ -1,0 +1,32 @@
+diff -urN rbenv-1.1.1-orig/src/configure rbenv-1.1.1/src/configure
+--- rbenv-1.1.1-orig/src/configure	2017-08-07 12:34:46.002506978 +0200
++++ rbenv-1.1.1/src/configure	2017-08-07 13:08:16.000000000 +0200
+@@ -34,16 +34,16 @@
+ eval "$("$src_dir"/shobj-conf -C "$CC" -o "$host_os")"
+ 
+ sed "
+-  s,@CC@,${CC},
+-  s,@CFLAGS@,${CFLAGS},
+-  s,@LOCAL_CFLAGS@,${LOCAL_CFLAGS},
+-  s,@DEFS@,${DEFS},
+-  s,@LOCAL_DEFS@,${LOCAL_DEFS},
+-  s,@SHOBJ_CC@,${SHOBJ_CC},
+-  s,@SHOBJ_CFLAGS@,${SHOBJ_CFLAGS},
+-  s,@SHOBJ_LD@,${SHOBJ_LD},
+-  s,@SHOBJ_LDFLAGS@,${SHOBJ_LDFLAGS//,/\\,},
+-  s,@SHOBJ_XLDFLAGS@,${SHOBJ_XLDFLAGS//,/\\,},
+-  s,@SHOBJ_LIBS@,${SHOBJ_LIBS},
+-  s,@SHOBJ_STATUS@,${SHOBJ_STATUS},
++  s#@CC@#${CC}#
++  s#@CFLAGS@#${CFLAGS}#
++  s#@LOCAL_CFLAGS@#${LOCAL_CFLAGS}#
++  s#@DEFS@#${DEFS}#
++  s#@LOCAL_DEFS@#${LOCAL_DEFS}#
++  s#@SHOBJ_CC@#${SHOBJ_CC}#
++  s#@SHOBJ_CFLAGS@#${SHOBJ_CFLAGS}#
++  s#@SHOBJ_LD@#${SHOBJ_LD}#
++  s#@SHOBJ_LDFLAGS@#${SHOBJ_LDFLAGS//,/\\,}#
++  s#@SHOBJ_XLDFLAGS@#${SHOBJ_XLDFLAGS//,/\\,}#
++  s#@SHOBJ_LIBS@#${SHOBJ_LIBS}#
++  s#@SHOBJ_STATUS@#${SHOBJ_STATUS}#
+ " "$src_dir"/Makefile.in > "$src_dir"/Makefile

--- a/rbenv/SOURCES/rbenv-default-root.patch
+++ b/rbenv/SOURCES/rbenv-default-root.patch
@@ -1,0 +1,12 @@
+diff -urN rbenv-1.1.1-orig/libexec/rbenv rbenv-1.1.1/libexec/rbenv
+--- rbenv-1.1.1-orig/libexec/rbenv	2017-08-07 12:34:46.006506992 +0200
++++ rbenv-1.1.1/libexec/rbenv	2017-08-07 12:36:09.000000000 +0200
+@@ -51,7 +51,7 @@
+ fi
+ 
+ if [ -z "${RBENV_ROOT}" ]; then
+-  RBENV_ROOT="${HOME}/.rbenv"
++  RBENV_ROOT="/usr/local/rbenv"
+ else
+   RBENV_ROOT="${RBENV_ROOT%/}"
+ fi

--- a/rbenv/rbenv.spec
+++ b/rbenv/rbenv.spec
@@ -28,7 +28,6 @@
 
 ###############################################################################
 
-%define install_dir       %{_loc_prefix}/%{name}
 %define profile_dir       %{_sysconfdir}/profile.d
 %define profile           %{profile_dir}/%{name}.sh
 
@@ -37,7 +36,7 @@
 Summary:         Simple Ruby version management utility
 Name:            rbenv
 Version:         1.1.1
-Release:         0%{?dist}
+Release:         1%{?dist}
 License:         MIT
 Group:           Development/Tools
 URL:             https://github.com/sstephenson/rbenv
@@ -46,10 +45,12 @@ Source0:         https://github.com/rbenv/%{name}/archive/v%{version}.tar.gz
 Source1:         %{name}.profile
 
 Patch0:          %{name}-init-fix.patch
+Patch1:          %{name}-default-root.patch
+Patch2:          %{name}-configure-sed.patch
+
+BuildRequires:   make gcc
 
 BuildRoot:       %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
-
-BuildArch:       noarch
 
 Provides:        %{name} = %{version}-%{release}
 
@@ -66,15 +67,25 @@ tradition of single-purpose tools that do one thing well.
 %setup -q -n %{name}-%{version}
 
 %patch0 -p1
+%patch1 -p1
+%patch2 -p1
 
 %build
 
+pushd src
+%configure
+%{__make} %{?_smp_mflags}
+popd
+
 %install
-%{__rm} -rf %{buildroot}
+rm -rf %{buildroot}
 
 install -dm 0755 %{buildroot}%{_loc_prefix}/%{name}
 install -dm 0755 %{buildroot}%{profile_dir}
 install -dm 0755 %{buildroot}%{_bindir}
+
+install -dm 0755 %{buildroot}%{_loc_prefix}/%{name}/versions
+install -dm 0755 %{buildroot}%{_loc_prefix}/%{name}/shims
 
 cp -r bin libexec completions LICENSE %{buildroot}%{_loc_prefix}/%{name}/
 
@@ -82,23 +93,23 @@ install -pm 755 %{SOURCE1} %{buildroot}%{profile}
 
 ln -sf %{_loc_prefix}/%{name}/libexec/rbenv %{buildroot}%{_bindir}/%{name}
 
-%post
-%{profile}
-
 %clean
-%{__rm} -rf %{buildroot}
+rm -rf %{buildroot}
 
 ###############################################################################
 
 %files
 %defattr(-,root,root,-)
-%{install_dir}
+%{_loc_prefix}/%{name}
 %{profile}
 %{_bindir}/%{name}
 
 ###############################################################################
 
 %changelog
+* Mon Aug 07 2017 Anton Novojilov <andy@essentialkaos.com> - 1.1.1-1
+- Improvements
+
 * Mon Jul 10 2017 Anton Novojilov <andy@essentialkaos.com> - 1.1.1-0
 - Fix setting environment variable in fish shell
 - Rename OLD_RBENV_VERSION to RBENV_* convention

--- a/x264.spec
+++ b/x264.spec
@@ -37,8 +37,8 @@
 ###############################################################################
 
 # Found X264_BUILD in (x264.h)
-%define pkg_build            150
-%define pkg_snapshot_date    20170709
+%define pkg_build            151
+%define pkg_snapshot_date    20170711
 %define pkg_snapshot_prefix  2245
 
 %define pkg_snapshot_version %{pkg_snapshot_date}-%{pkg_snapshot_prefix}
@@ -99,9 +99,11 @@ rm -rf %{buildroot}
 %clean
 rm -rf %{buildroot}
 
-%post -p /sbin/ldconfig
+%post
+/sbin/ldconfig
 
-%postun -p /sbin/ldconfig
+%postun
+/sbin/ldconfig
 
 ###############################################################################
 
@@ -121,6 +123,9 @@ rm -rf %{buildroot}
 ###############################################################################
 
 %changelog
+* Wed Jul 12 2017 Anton Novojilov <andy@essentialkaos.com> - 0.151_20170711-0
+- Update to latest stable snapshot
+
 * Mon Jul 10 2017 Anton Novojilov <andy@essentialkaos.com> - 0.150_20170709-0
 - Update to latest stable snapshot
 


### PR DESCRIPTION
Hi there,

I have tried HAProxy from EK repository and found that `ExecReload` handler is missing. I ask you to rebuild packages to support applying changes to daemon without restarting the process. For example, this feature is important part of [marathon-lb](https://github.com/mesosphere/marathon-lb) program which use `systemctl reload haproxy` to apply discovered facts of running instances of application from Marathon API.