### PR TITLE
Add ExecReload handler to HAProxy systemd unit

### DIFF
--- a/haproxy-1.5/SOURCES/haproxy.service
+++ b/haproxy-1.5/SOURCES/haproxy.service
@@ -6,6 +6,9 @@ After=syslog.target network.target
 PIDFile=/var/run/haproxy.pid
 ExecStart=/etc/init.d/haproxy start
 ExecStop=/etc/init.d/haproxy stop
+ExecReload=/bin/kill -SIGUSR1 $MAINPID
+KillMode=mixed
+Restart=always
 
 [Install]
 WantedBy=multi-user.target

--- a/haproxy-1.6/SOURCES/haproxy.service
+++ b/haproxy-1.6/SOURCES/haproxy.service
@@ -6,6 +6,9 @@ After=syslog.target network.target
 PIDFile=/var/run/haproxy.pid
 ExecStart=/etc/init.d/haproxy start
 ExecStop=/etc/init.d/haproxy stop
+ExecReload=/bin/kill -SIGUSR1 $MAINPID
+KillMode=mixed
+Restart=always
 
 [Install]
 WantedBy=multi-user.target

--- a/haproxy-1.7/SOURCES/haproxy.service
+++ b/haproxy-1.7/SOURCES/haproxy.service
@@ -6,6 +6,9 @@ After=syslog.target network.target
 PIDFile=/var/run/haproxy.pid
 ExecStart=/etc/init.d/haproxy start
 ExecStop=/etc/init.d/haproxy stop
+ExecReload=/bin/kill -SIGUSR1 $MAINPID
+KillMode=mixed
+Restart=always
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Hi there,

I have tried HAProxy from the repository and found that `ExecReload` handler is missing. I ask you to rebuild packages to support applying changes to daemon without restarting the process. For example, this feature is important part of [marathon-lb](https://github.com/mesosphere/marathon-lb) program which uses `systemctl reload haproxy` command to apply discovered facts of running instances of application from Marathon API.