### PR TITLE
HAProxy systemd ExecReload handler

### DIFF
--- a/haproxy-1.5/SOURCES/haproxy.service
+++ b/haproxy-1.5/SOURCES/haproxy.service
@@ -6,7 +6,7 @@ After=syslog.target network.target
 PIDFile=/var/run/haproxy.pid
 ExecStart=/etc/init.d/haproxy start
 ExecStop=/etc/init.d/haproxy stop
-ExecReload=/bin/kill -SIGUSR1 $MAINPID
+ExecReload=/etc/init.d/haproxy reload
 KillMode=mixed
 Restart=always
 

--- a/haproxy-1.6/SOURCES/haproxy.service
+++ b/haproxy-1.6/SOURCES/haproxy.service
@@ -6,7 +6,7 @@ After=syslog.target network.target
 PIDFile=/var/run/haproxy.pid
 ExecStart=/etc/init.d/haproxy start
 ExecStop=/etc/init.d/haproxy stop
-ExecReload=/bin/kill -SIGUSR1 $MAINPID
+ExecReload=/etc/init.d/haproxy reload
 KillMode=mixed
 Restart=always
 

--- a/haproxy-1.7/SOURCES/haproxy.service
+++ b/haproxy-1.7/SOURCES/haproxy.service
@@ -6,7 +6,7 @@ After=syslog.target network.target
 PIDFile=/var/run/haproxy.pid
 ExecStart=/etc/init.d/haproxy start
 ExecStop=/etc/init.d/haproxy stop
-ExecReload=/bin/kill -SIGUSR1 $MAINPID
+ExecReload=/etc/init.d/haproxy reload
 KillMode=mixed
 Restart=always
 


### PR DESCRIPTION
I found that I was wrong when specified `SIGUSR1` signal for graceful reloading. According to documentation of HAProxy, is more appropriate way for graceful reloading and applying configuration is option `-sf` which does `SIGTTOU`, `SIGTTIN` and then `SIGUSR1`.