### PR TITLE
lsyncd: fix invalid path to binary in systemd unit

### DIFF
--- a/lsyncd/SOURCES/lsyncd.service
+++ b/lsyncd/SOURCES/lsyncd.service
@@ -6,7 +6,7 @@ After=network.target
 Type=simple
 Nice=19
 EnvironmentFile=-/etc/sysconfig/lsyncd
-ExecStart=/usr/bin/sh -c 'eval `/usr/bin/lsyncd -nodaemon $LSYNCD_OPTIONS /etc/lsyncd.conf`'
+ExecStart=/usr/bin/sh -c 'eval `/usr/local/bin/lsyncd -nodaemon $LSYNCD_OPTIONS /etc/lsyncd.conf`'
 
 [Install]
 WantedBy=multi-user.target

--- a/lsyncd/lsyncd.spec
+++ b/lsyncd/lsyncd.spec
@@ -46,7 +46,7 @@
 Summary:              File change monitoring and synchronization daemon
 Name:                 lsyncd
 Version:              2.2.2
-Release:              0%{?dist}
+Release:              1%{?dist}
 License:              GPLv2+
 Group:                Applications/Internet
 URL:                  https://github.com/axkibe/lsyncd
@@ -168,6 +168,9 @@ fi
 ###############################################################################
 
 %changelog
+* Mon Aug 28 2017 Gleb Goncharov <inbox@gongled.ru> - 2.2.2-1
+- Fixed invalid path to binary in systemd unit file
+
 * Wed Mar 22 2017 Anton Novojilov <andy@essentialkaos.com> - 2.2.2-0
 - Updated to latest stable release
 


### PR DESCRIPTION
Hi, @andyone 

I found that lsyncd.service file contain invalid path to binary file (`/usr/bin/lsyncd` instead of `/usr/local/bin/lsyncd`), so I decided to prepare PR. Luckily, problem does not affect CentOS 6 systems.