### PR TITLE
Add shapelib RPM spec

### DIFF
--- a/shapelib.spec
+++ b/shapelib.spec
@@ -1,9 +1,5 @@
 ###############################################################################
 
-# rpmbuilder:qa-rpaths 0x0001,0x0002
-
-###############################################################################
-
 Summary:         C library for handling ESRI Shapefiles
 Name:            shapelib
 Version:         1.4.0
@@ -16,7 +12,7 @@ Source:          http://download.osgeo.org/%{name}/%{name}-%{version}.tar.gz
 
 BuildRoot:       %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
-BuildRequires:   gcc-c++ make proj-devel
+BuildRequires:   gcc-c++ make proj-devel chrpath
 
 Provides:        %{name} = %{version}-%{release}
 
@@ -60,6 +56,9 @@ rm -rf %{buildroot}
 %{make_install}
 
 find %{buildroot} -name '*.la' -exec rm -f {} ';'
+
+chrpath --delete %{buildroot}%{_bindir}/*
+chrpath --delete %{buildroot}%{_libdir}/*.so*
 
 %clean
 rm -rf %{buildroot}

--- a/shapelib.spec
+++ b/shapelib.spec
@@ -1,5 +1,9 @@
 ###############################################################################
 
+# rpmbuilder:qa-rpaths 0x0001,0x0002
+
+###############################################################################
+
 Summary:         C library for handling ESRI Shapefiles
 Name:            shapelib
 Version:         1.4.0
@@ -52,15 +56,19 @@ This package contains various utility programs distributed with shapelib.
 %{__make} %{?_smp_mflags}
 
 %install
+rm -rf %{buildroot}
 %{make_install}
 
 find %{buildroot} -name '*.la' -exec rm -f {} ';'
 
+%clean
+rm -rf %{buildroot}
+
 %post 
-%{__ldconfig}
+/sbin/ldconfig
 
 %postun
-%{__ldconfig}
+/sbin/ldconfig
 
 ###############################################################################
 

--- a/shapelib.spec
+++ b/shapelib.spec
@@ -1,0 +1,85 @@
+###############################################################################
+
+Summary:         C library for handling ESRI Shapefiles
+Name:            shapelib
+Version:         1.4.0
+Release:         0%{?dist}
+License:         (LGPLv2+ or MIT) and GPLv2+ and Public Domain
+Group:           Development/Libraries
+URL:             http://shapelib.maptools.org/
+
+Source:          http://download.osgeo.org/%{name}/%{name}-%{version}.tar.gz
+
+BuildRoot:       %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+
+BuildRequires:   gcc-c++ make proj-devel
+
+Provides:        %{name} = %{version}-%{release}
+
+###############################################################################
+
+%description
+The Shapefile C Library provides the ability to write
+simple C programs for reading, writing and updating (to a
+limited extent) ESRI Shapefiles, and the associated
+attribute file (.dbf).
+
+###############################################################################
+
+%package devel
+Summary:         Development files for shapelib
+Requires:        %{name} = %{version}-%{release}
+
+%description devel
+This package contains libshp and the appropriate header files.
+
+###############################################################################
+
+%package tools
+Summary:         shapelib utility programs
+Requires:        %{name} = %{version}-%{release}
+
+%description tools
+This package contains various utility programs distributed with shapelib.
+
+###############################################################################
+
+%prep
+%setup -q
+
+%build
+%configure --disable-static
+%{__make} %{?_smp_mflags}
+
+%install
+%{make_install}
+
+find %{buildroot} -name '*.la' -exec rm -f {} ';'
+
+%post 
+%{__ldconfig}
+
+%postun
+%{__ldconfig}
+
+###############################################################################
+
+%files
+%doc README README.tree ChangeLog web/*.html COPYING
+%{_libdir}/libshp.so.2*
+
+%files devel
+%{_includedir}/shapefil.h
+%{_libdir}/libshp.so
+%{_libdir}/pkgconfig/%{name}.pc
+
+%files tools
+%doc contrib/doc/
+%{_bindir}/*
+
+###############################################################################
+
+%changelog
+* Thu Sep 07 2017 Gleb Goncharov <inbox@gongled.ru> - 1.4.0-0
+- Initial build.
+

--- a/shapelib.spec
+++ b/shapelib.spec
@@ -73,15 +73,18 @@ rm -rf %{buildroot}
 ###############################################################################
 
 %files
+%defattr(-,root,root,-)
 %doc README README.tree ChangeLog web/*.html COPYING
 %{_libdir}/libshp.so.2*
 
 %files devel
+%defattr(-,root,root,-)
 %{_includedir}/shapefil.h
 %{_libdir}/libshp.so
 %{_libdir}/pkgconfig/%{name}.pc
 
 %files tools
+%defattr(-,root,root,-)
 %doc contrib/doc/
 %{_bindir}/*
 


### PR DESCRIPTION
Hey, @andyone.

I found that `shapelib-devel` package from EPEL repository require fewer version of `proj-devel` than we have in EK repository. 