### PR TITLE
Update memcached to 1.5.3

### DIFF
--- a/memcached/SOURCES/memcached.init
+++ b/memcached/SOURCES/memcached.init
@@ -29,6 +29,7 @@ kv[prog_name]="memcached"
 kv.readSysconfig
 
 binary="${BINARY:-/usr/bin/memcached}"
+listen="${LISTEN:-127.0.0.1}"
 port="${PORT:-11211}"
 user="${USER:-memcached}"
 max_conn="${MAX_CONN:-1024}"
@@ -59,9 +60,9 @@ startServiceHandler() {
       "3") log_arg="-vvv" ;;
     esac
 
-    kv.run "$binary -d -P ${kv[pid_file]} -u $user -p $port -m $cache_size -c $max_conn $options $log_arg >> $log_file 2>&1"
+    kv.run "$binary -d -P ${kv[pid_file]} -u $user -l $listen -p $port -m $cache_size -c $max_conn $options $log_arg >> $log_file 2>&1"
   else 
-    kv.run "$binary -d -P ${kv[pid_file]} -u $user -p $port -m $cache_size -c $max_conn $options"
+    kv.run "$binary -d -P ${kv[pid_file]} -u $user -l $listen -p $port -m $cache_size -c $max_conn $options"
   fi
 
   [[ $? -ne 0 ]] && return $ACTION_ERROR

--- a/memcached/SOURCES/memcached.service
+++ b/memcached/SOURCES/memcached.service
@@ -4,7 +4,7 @@ Before=httpd.service
 After=network.target
 
 [Service]
-EnvironmentFile=-/etc/sysconfig/memcached
+EnvironmentFile=/etc/sysconfig/memcached
 Type=forking
 ExecStart=/usr/bin/memcached -d -l $LISTEN -p $PORT -m $CACHE_SIZE -c $MAX_CONN -u $USER $OPTIONS
 

--- a/memcached/SOURCES/memcached.service
+++ b/memcached/SOURCES/memcached.service
@@ -4,9 +4,9 @@ Before=httpd.service
 After=network.target
 
 [Service]
-PIDFile=/var/run/memcached/memcached.pid
-ExecStart=/etc/init.d/memcached start
-ExecStop=/etc/init.d/memcached stop
+EnvironmentFile=-/etc/sysconfig/memcached
+Type=forking
+ExecStart=/usr/bin/memcached -d -l $LISTEN -p $PORT -m $CACHE_SIZE -c $MAX_CONN -u $USER $OPTIONS
 
 [Install]
 WantedBy=multi-user.target

--- a/memcached/SOURCES/memcached.sysconf
+++ b/memcached/SOURCES/memcached.sysconf
@@ -1,5 +1,8 @@
 # Sysconfig for memcached service
 
+# IP
+LISTEN=127.0.0.1
+
 # Port
 PORT=11211
 

--- a/memcached/memcached.spec
+++ b/memcached/memcached.spec
@@ -58,7 +58,7 @@ Source3:                  %{name}.service
 
 BuildRoot:                %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
-BuildRequires:            gcc automake git which
+BuildRequires:            gcc automake which
 
 %if 0%{?rhel} <= 6
 Requires:                 initscripts kaosv >= 2.12

--- a/memcached/memcached.spec
+++ b/memcached/memcached.spec
@@ -237,7 +237,7 @@ fi
 - Fixed -o no_hashexpand to disable hash table expansion
 - Fixed chunked items set in binprot, read from ascii
 
-* Mon Nov 06 2017 Gleb Goncharov <g.goncharov@fun-box.ru> - 1.5.3-0
+* Mon Nov 06 2017 Gleb Goncharov <g.goncharov@fun-box.ru> - 1.5.2-0
 - Fixed more binary protocol documentation errors.
 - Fixed segfault during 31b -> 32b hash table expand
 - Create hashtables larger than 32bit

--- a/memcached/memcached.spec
+++ b/memcached/memcached.spec
@@ -45,7 +45,7 @@
 
 Summary:                  High Performance, Distributed Memory Object Cache
 Name:                     memcached
-Version:                  1.5.1
+Version:                  1.5.3
 Release:                  0%{?dist}
 Group:                    System Environment/Daemons
 License:                  BSD
@@ -58,9 +58,11 @@ Source3:                  %{name}.service
 
 BuildRoot:                %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
-BuildRequires:            gcc automake
+BuildRequires:            gcc automake git which
 
+%if 0%{?rhel} <= 6
 Requires:                 initscripts kaosv >= 2.12
+%endif
 
 %if 0%{?rhel} >= 7
 BuildRequires:            libevent-devel
@@ -132,12 +134,16 @@ sed -i "s/UNKNOWN/%{version}/" version.m4
 %{make_install} INSTALL="install -p"
 
 install -dm 755 %{buildroot}%{_bindir}
+%if 0%{?rhel} <= 6
 install -dm 755 %{buildroot}%{_initrddir}
+%endif
 install -dm 755 %{buildroot}%{_sysconfdir}/sysconfig
 install -dm 755 %{buildroot}%{_rundir}/%{name}
 install -dm 755 %{buildroot}%{_logdir}/%{name}
 
+%if 0%{?rhel} <= 6
 install -pm 755 %{SOURCE1} %{buildroot}%{_initrddir}/%{name}
+%endif
 install -pm 644 %{SOURCE2} %{buildroot}%{_sysconfdir}/sysconfig/%{name}
 
 %if 0%{?rhel} >= 7
@@ -197,7 +203,9 @@ fi
 %{_bindir}/%{name}-tool
 %{_bindir}/%{name}
 %{_mandir}/man1/%{name}.1*
+%if 0%{?rhel} <= 6
 %{_initrddir}/%{name}
+%endif
 
 %if 0%{?rhel} >= 7
 %{_unitdir}/%{name}.service
@@ -217,6 +225,24 @@ fi
 ###############################################################################
 
 %changelog
+* Mon Nov 06 2017 Gleb Goncharov <g.goncharov@fun-box.ru> - 1.5.3-0
+- Added listen option to support bindings on IP address
+- Improved systemd unit file
+- Added get and touch command for ascii protocol
+- Added warning about time on very low TTL's in doc/protocol.txt
+- Pledged privdropping support for OpenBSD
+- Made for loop more clear in logger watcher
+- Fixed theoretical leak in process_bin_stat
+- Fixed use of unitialized array in lru_maintainer
+- Fixed -o no_hashexpand to disable hash table expansion
+- Fixed chunked items set in binprot, read from ascii
+
+* Mon Nov 06 2017 Gleb Goncharov <g.goncharov@fun-box.ru> - 1.5.3-0
+- Fixed more binary protocol documentation errors.
+- Fixed segfault during 31b -> 32b hash table expand
+- Create hashtables larger than 32bit
+- Some non-user-facing code changes for supporting future features.
+
 * Sat Sep 16 2017 Anton Novojilov <andy@essentialkaos.com> - 1.5.1-0
 - Add max_connections stat to 'stats' output
 - Drop sockets from obviously malicious command strings (HTTP/)


### PR DESCRIPTION
I also made the following fixes for a `memcached` update:

- Added `listen` option for an IP binding support.
- Improved `systemd` unit file without `kaosv` dependency.