### PR TITLE
Add HAProxy 1.8

### DIFF
--- a/haproxy-1.8/SOURCES/haproxy.cfg
+++ b/haproxy-1.8/SOURCES/haproxy.cfg
@@ -1,0 +1,65 @@
+#---------------------------------------------------------------------
+# Example configuration for a possible web application.  See the
+# full configuration options online.
+#
+#   http://haproxy.1wt.eu/download/1.4/doc/configuration.txt
+#
+#---------------------------------------------------------------------
+
+#---------------------------------------------------------------------
+# Global settings
+#---------------------------------------------------------------------
+global
+    # to have these messages end up in /var/log/haproxy.log you will
+    # need to:
+    #
+    # 1) configure syslog to accept network log events.  This is done
+    #    by adding the '-r' option to the SYSLOGD_OPTIONS in
+    #    /etc/sysconfig/syslog
+    #
+    # 2) configure local2 events to go to the /var/log/haproxy.log
+    #   file. A line like the following can be added to
+    #   /etc/sysconfig/syslog
+    #
+    #    local2.*                       /var/log/haproxy.log
+    #
+    log         127.0.0.1 local2
+
+    chroot      /var/lib/haproxy
+    pidfile     /var/run/haproxy.pid
+    maxconn     4000
+    user        haproxy
+    group       haproxy
+    daemon
+
+    # SSL configuration
+    tune.ssl.default-dh-param 2048
+    ssl-default-bind-ciphers ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256
+    ssl-default-bind-options no-sslv3 no-tlsv10 no-tlsv11 no-tls-tickets
+    ssl-default-server-ciphers ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256
+    ssl-default-server-options no-sslv3 no-tlsv10 no-tlsv11 no-tls-tickets
+
+    # turn on stats unix socket
+    stats socket /var/lib/haproxy/stats
+
+#---------------------------------------------------------------------
+# common defaults that all the 'listen' and 'backend' sections will
+# use if not designated in their block
+#---------------------------------------------------------------------
+defaults
+    mode                    http
+    log                     global
+    option                  httplog
+    option                  dontlognull
+    option http-server-close
+    option forwardfor       except 127.0.0.0/8
+    option                  redispatch
+    retries                 3
+    timeout http-request    10s
+    timeout queue           1m
+    timeout connect         10s
+    timeout client          1m
+    timeout server          1m
+    timeout http-keep-alive 10s
+    timeout check           10s
+    maxconn                 3000

--- a/haproxy-1.8/SOURCES/haproxy.init
+++ b/haproxy-1.8/SOURCES/haproxy.init
@@ -1,0 +1,162 @@
+#!/bin/bash
+
+# chkconfig: - 85 15
+# description: HA-Proxy is a TCP/HTTP reverse proxy which is particularly suited \
+#              for high availability environments.
+# processname: haproxy
+# config:      /etc/haproxy/haproxy.cfg
+# pidfile:     /var/run/haproxy.pid
+
+###############################################################################
+
+source /etc/init.d/kaosv
+
+###############################################################################
+
+kv[prog_name]="haproxy"
+
+kv.readSysconfig
+
+binary=${BINARY:-/usr/sbin/haproxy}
+conf_file=${CONF_FILE:-/etc/haproxy/haproxy.cfg}
+
+kv[pid_file]="/var/run/haproxy.pid"
+
+kv[delay_start]=${DELAY_START:-15}
+kv[delay_stop]=${DELAY_STOP:-120}
+
+kv[search_pattern]="$binary -D -f $conf_file -p ${kv[pid_file]}"
+
+###############################################################################
+
+kv.addCommand "start"    "Start ${kv[prog_name]}"
+kv.addCommand "stop"     "Stop ${kv[prog_name]}"
+kv.addCommand "restart"  "Restart (stop+start) ${kv[prog_name]}"    "restart"
+kv.addCommand "status"   "Show current status of ${kv[prog_name]}"
+kv.addCommand "reload"   "Reload configuration files"               "reload"
+kv.addCommand "check"    "Validate config"                          "check"
+
+kv.addCommandVars "stop" "force"
+
+kv.addHandler "start" "startServiceHandler"
+kv.addHandler "start" "preStartServiceHandler" "pre"
+kv.addHandler "stop"  "stopServiceHandler"
+
+kv.disableOutputRedirect "start" "pre"
+
+###############################################################################
+
+prepare() {
+  local has_errors=""
+
+  [[ ! -f $binary ]] && has_errors=true && kv.error "Error! File <$binary> is not exist"
+  [[ ! -x $binary ]] && has_errors=true && kv.error "Error! File <$binary> is not executable"
+
+  [[ ! -f $conf_file ]] && has_errors=true && kv.error "Error! File <$conf_file> is not exist"
+  [[ ! -r $conf_file ]] && has_errors=true && kv.error "Error! File <$conf_file> is not readable"
+
+  [[ $has_errors ]] && kv.exit $ACTION_ERROR
+}
+
+###############################################################################
+
+reload() {
+  if ! check ; then
+    return $ACTION_ERROR
+  fi
+
+  kv.showProcessMessage "Reloading config"
+
+  $binary -D -f "$conf_file" -p "${kv[pid_file]}" -sf $(cat "${kv[pid_file]}") &> /dev/null
+
+  local status=$?
+
+  kv.showStatusMessage "$status"
+
+  return $status
+}
+
+check() {
+  kv.showProcessMessage "Checking ${kv[prog_name]} config"
+
+  testServiceConfig true
+
+  local status=$?
+
+  kv.showStatusMessage "$status"
+
+  if [[ $status -ne 0 ]] ; then
+    kv.show "-------------------------------------------------------------------------------" $GREY
+    testServiceConfig
+    kv.show "-------------------------------------------------------------------------------" $GREY
+    return $ACTION_ERROR
+  fi
+
+  return $ACTION_OK
+}
+
+restart() {
+  if check ; then
+    kv.restart
+  fi
+
+  return $?
+}
+
+###############################################################################
+
+preStartServiceHandler() {
+  if ! testServiceConfig true ; then
+    kv.show "-------------------------------------------------------------------------------" $GREY
+    testServiceConfig
+    kv.show "-------------------------------------------------------------------------------" $GREY
+    return $ACTION_ERROR
+  fi
+}
+
+startServiceHandler() {
+
+  $binary -D -f "$conf_file" -p "${kv[pid_file]}"
+
+  [[ $? -ne $ACTION_OK ]] && return $ACTION_ERROR
+
+  kv.getStartStatus
+
+  return $?
+}
+
+stopServiceHandler() {
+  local pid=`kv.getPid`
+
+  kv.sendSignal "$SIGNAL_USR1"
+
+  if kv.getStopStatus ; then
+    return $ACTION_OK
+  else
+    if [[ -n "$1" ]] ; then
+      kv.killProcess "$pid"
+    fi
+
+    return $ACTION_ERROR
+  fi
+}
+
+###############################################################################
+
+testServiceConfig() {
+  local quiet="$1"
+
+  if [[ $quiet ]] ; then
+    $binary -c -q -f "$conf_file" &> /dev/null
+  else
+    $binary -c -V -f "$conf_file"
+  fi
+
+  local status=$?
+}
+
+###############################################################################
+
+prepare
+
+kv.go $@

--- a/haproxy-1.8/SOURCES/haproxy.logrotate
+++ b/haproxy-1.8/SOURCES/haproxy.logrotate
@@ -1,0 +1,12 @@
+/var/log/haproxy.log {
+    daily
+    rotate 10
+    missingok
+    notifempty
+    compress
+    sharedscripts
+    postrotate
+        /bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true
+        /bin/kill -HUP `cat /var/run/rsyslogd.pid 2> /dev/null` 2> /dev/null || true
+    endscript
+}

--- a/haproxy-1.8/SOURCES/haproxy.service
+++ b/haproxy-1.8/SOURCES/haproxy.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=HAProxy Load Balancer
+After=syslog.target network.target
+
+[Service]
+PIDFile=/var/run/haproxy.pid
+ExecStart=/etc/init.d/haproxy start
+ExecStop=/etc/init.d/haproxy stop
+ExecReload=/etc/init.d/haproxy reload
+KillMode=mixed
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/haproxy-1.8/SOURCES/haproxy.sysconfig
+++ b/haproxy-1.8/SOURCES/haproxy.sysconfig
@@ -1,0 +1,6 @@
+# Sysconfig for haproxy service
+
+BINARY=""
+CONF_FILE=""
+DELAY_START=""
+DELAY_STOP=""

--- a/haproxy-1.8/haproxy18.spec
+++ b/haproxy-1.8/haproxy18.spec
@@ -1,0 +1,300 @@
+###############################################################################
+
+%define _posixroot        /
+%define _root             /root
+%define _bin              /bin
+%define _sbin             /sbin
+%define _srv              /srv
+%define _home             /home
+%define _lib32            %{_posixroot}lib
+%define _lib64            %{_posixroot}lib64
+%define _libdir32         %{_prefix}%{_lib32}
+%define _libdir64         %{_prefix}%{_lib64}
+%define _logdir           %{_localstatedir}/log
+%define _rundir           %{_localstatedir}/run
+%define _lockdir          %{_localstatedir}/lock
+%define _cachedir         %{_localstatedir}/cache
+%define _spooldir         %{_localstatedir}/spool
+%define _loc_prefix       %{_prefix}/local
+%define _loc_exec_prefix  %{_loc_prefix}
+%define _loc_bindir       %{_loc_exec_prefix}/bin
+%define _loc_libdir       %{_loc_exec_prefix}/%{_lib}
+%define _loc_libdir32     %{_loc_exec_prefix}/%{_lib32}
+%define _loc_libdir64     %{_loc_exec_prefix}/%{_lib64}
+%define _loc_libexecdir   %{_loc_exec_prefix}/libexec
+%define _loc_sbindir      %{_loc_exec_prefix}/sbin
+%define _loc_bindir       %{_loc_exec_prefix}/bin
+%define _loc_datarootdir  %{_loc_prefix}/share
+%define _loc_includedir   %{_loc_prefix}/include
+%define _rpmstatedir      %{_sharedstatedir}/rpm-state
+%define _pkgconfigdir     %{_libdir}/pkgconfig
+
+%define __ln              %{_bin}/ln
+%define __touch           %{_bin}/touch
+%define __service         %{_sbin}/service
+%define __chkconfig       %{_sbin}/chkconfig
+%define __sysctl          %{_bindir}/systemctl
+
+%define __useradd         %{_sbindir}/useradd
+%define __groupadd        %{_sbindir}/groupadd
+%define __userdel         %{_sbindir}/userdel
+%define __getent          %{_bindir}/getent
+
+###############################################################################
+
+%define hp_user           %{name}
+%define hp_user_id        188
+%define hp_group          %{name}
+%define hp_group_id       188
+%define hp_homedir        %{_localstatedir}/lib/%{name}
+%define hp_confdir        %{_sysconfdir}/%{name}
+%define hp_datadir        %{_datadir}/%{name}
+
+%define lua_ver           5.3.4
+%define pcre_ver          8.41
+%define boringssl_ver     664e99a6486c293728097c661332f92bf2d847c6
+%define ncurses_ver       6.0
+%define readline_ver      7.0
+
+###############################################################################
+
+Name:              haproxy
+Summary:           TCP/HTTP reverse proxy for high availability environments
+Version:           1.8.0
+Release:           0%{?dist}
+License:           GPLv2+
+URL:               http://haproxy.1wt.eu
+Group:             System Environment/Daemons
+
+Source0:           http://www.haproxy.org/download/1.8/src/%{name}-%{version}.tar.gz
+Source1:           %{name}.init
+Source2:           %{name}.cfg
+Source3:           %{name}.logrotate
+Source4:           %{name}.sysconfig
+Source5:           %{name}.service
+
+Source10:          http://www.lua.org/ftp/lua-%{lua_ver}.tar.gz
+Source11:          http://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre-%{pcre_ver}.tar.gz
+Source12:          https://boringssl.googlesource.com/boringssl/+archive/%{boringssl_ver}.tar.gz
+Source13:          https://ftp.gnu.org/pub/gnu/ncurses/ncurses-%{ncurses_ver}.tar.gz
+Source14:          https://ftp.gnu.org/gnu/readline/readline-%{readline_ver}.tar.gz
+
+BuildRoot:         %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+
+BuildRequires:     make gcc gcc-c++ cmake golang zlib-devel openssl-devel
+
+Requires:          setup >= 2.8.14-14 kaosv >= 2.10
+
+%if 0%{?rhel} >= 7
+Requires(pre):     shadow-utils
+Requires(post):    systemd
+Requires(preun):   systemd
+Requires(postun):  systemd
+%else
+Requires(pre):     shadow-utils
+Requires(post):    chkconfig
+Requires(preun):   chkconfig
+Requires(preun):   initscripts
+Requires(postun):  initscripts
+%endif
+
+Provides:          %{name} = %{version}-%{release}
+
+###############################################################################
+
+%description
+HAProxy is a free, fast and reliable solution offering high
+availability, load balancing, and proxying for TCP and HTTP-based
+applications. It is particularly suited for web sites crawling under
+very high loads while needing persistence or Layer7 processing.
+Supporting tens of thousands of connections is clearly realistic with
+modern hardware. Its mode of operation makes integration with existing
+architectures very easy and riskless, while still offering the
+possibility not to expose fragile web servers to the net.
+
+###############################################################################
+
+%prep
+%setup -q
+
+mkdir boringssl
+
+%{__tar} xzvf %{SOURCE10}
+%{__tar} xzvf %{SOURCE11}
+%{__tar} xzvf %{SOURCE12} -C boringssl
+%{__tar} xzvf %{SOURCE13}
+%{__tar} xzvf %{SOURCE14}
+
+%build
+
+### DEPS BUILD START ###
+
+export BUILDDIR=$(pwd)
+
+# Static BoringSSL build
+mkdir boringssl/build
+
+pushd boringssl/build &> /dev/null
+  cmake ../
+  %{__make} %{?_smp_mflags}
+popd
+
+mkdir -p "boringssl/.openssl/lib"
+
+pushd boringssl/.openssl &> /dev/null
+  ln -s ../include
+popd
+
+cp boringssl/build/crypto/libcrypto.a boringssl/build/ssl/libssl.a boringssl/.openssl/lib
+
+# Static NCurses build
+pushd ncurses-%{ncurses_ver}
+  mkdir build
+  ./configure --prefix=$(pwd)/build --enable-shared=no
+  %{__make} %{?_smp_mflags}
+  %{__make} install
+popd
+
+# Static readline build
+pushd readline-%{readline_ver}
+  mkdir build
+  ./configure --prefix=$(pwd)/build --enable-static=true
+  %{__make} %{?_smp_mflags}
+  %{__make} install
+popd
+
+# Static Lua build
+pushd lua-%{lua_ver}
+  mkdir build
+  %{__make} %{?_smp_mflags} MYCFLAGS="-I$BUILDDIR/readline-%{readline_ver}/build/include" \
+                            MYLDFLAGS="-L$BUILDDIR/readline-%{readline_ver}/build/lib -L$BUILDDIR/ncurses-%{ncurses_ver}/build/lib -lreadline -lncurses" \
+                            linux
+  %{__make} %{?_smp_mflags} INSTALL_TOP=$(pwd)/build install
+popd
+
+# Static PCRE build
+pushd pcre-%{pcre_ver}
+  mkdir build
+  ./configure --prefix=$(pwd)/build --enable-shared=no --enable-utf8 --enable-jit
+  %{__make} %{?_smp_mflags}
+  %{__make} install
+popd
+
+### DEPS BUILD END ###
+
+%ifarch %ix86 x86_64
+use_regparm="USE_REGPARM=1"
+%endif
+
+%{__make} %{?_smp_mflags} CPU="generic" \
+                          TARGET="linux26" \
+                          USE_OPENSSL=1 \
+                          SSL_INC=boringssl/.openssl/include \
+                          SSL_LIB=boringssl/.openssl/lib \
+                          USE_PCRE_JIT=1 \
+                          USE_STATIC_PCRE=1 \
+                          PCRE_INC=pcre-%{pcre_ver}/build/include \
+                          PCRE_LIB=pcre-%{pcre_ver}/build/lib \
+                          USE_LUA=1 \
+                          LUA_INC=lua-%{lua_ver}/build/include \
+                          LUA_LIB=lua-%{lua_ver}/build/lib \
+                          USE_ZLIB=1 \
+                          ADDLIB="-ldl -lrt -lpthread" \
+                          ${use_regparm}
+
+pushd contrib/halog
+  %{__make} halog
+popd
+
+%install
+rm -rf %{buildroot}
+
+%{__make} install-bin DESTDIR=%{buildroot} PREFIX=%{_prefix}
+%{__make} install-man DESTDIR=%{buildroot} PREFIX=%{_prefix}
+
+install -pDm 0755 %{SOURCE1} %{buildroot}%{_initrddir}/%{name}
+install -pDm 0644 %{SOURCE2} %{buildroot}%{hp_confdir}/%{name}.cfg
+install -pDm 0644 %{SOURCE3} %{buildroot}%{_sysconfdir}/logrotate.d/%{name}
+install -pDm 0644 %{SOURCE4} %{buildroot}%{_sysconfdir}/sysconfig/%{name}
+
+install -dm 0755 %{buildroot}%{hp_homedir}
+install -dm 0755 %{buildroot}%{hp_datadir}
+install -dm 0755 %{buildroot}%{_bindir}
+
+%if 0%{?rhel} >= 7
+install -dm 755 %{buildroot}%{_unitdir}
+install -pm 644 %{SOURCE5} %{buildroot}%{_unitdir}/
+%endif
+
+install -pm 0755 ./contrib/halog/halog %{buildroot}%{_bindir}/halog
+install -pm 0644 ./examples/errorfiles/* %{buildroot}%{hp_datadir}
+
+for file in $(find . -type f -name '*.txt') ; do
+  iconv -f ISO-8859-1 -t UTF-8 -o $file.new $file && \
+  touch -r $file $file.new && \
+  mv $file.new $file
+done
+
+%clean
+rm -rf %{buildroot}
+
+%pre
+if [[ $1 -eq 1 ]] ; then
+  %{__getent} group %{hp_group} >/dev/null || %{__groupadd} -g %{hp_group_id} -r %{hp_group} 2>/dev/null
+  %{__getent} passwd %{hp_user} >/dev/null || %{__useradd} -r -u %{hp_user_id} -g %{hp_group} -d %{hp_homedir} -s /sbin/nologin %{hp_user} 2>/dev/null
+fi
+
+%post
+if [[ $1 -eq 1 ]] ; then
+%if 0%{?rhel} >= 7
+  %{__sysctl} enable %{name}.service &>/dev/null || :
+%else
+  %{__chkconfig} --add %{name} &>/dev/null || :
+%endif
+fi
+
+%preun
+if [[ $1 -eq 0 ]]; then
+%if 0%{?rhel} >= 7
+  %{__sysctl} --no-reload disable %{name}.service &>/dev/null || :
+  %{__sysctl} stop %{name}.service &>/dev/null || :
+%else
+  %{__service} %{name} stop >/dev/null 2>&1
+  %{__chkconfig} --del %{name} &>/dev/null || :
+%endif
+fi
+
+%postun
+%if 0%{?rhel} >= 7
+if [[ $1 -ge 1 ]] ; then
+  %{__sysctl} daemon-reload &>/dev/null || :
+fi
+%endif
+
+###############################################################################
+
+%files
+%defattr(-, root, root, -)
+%doc CHANGELOG LICENSE README doc/*
+%doc examples/*.cfg
+%dir %{hp_datadir}
+%dir %{hp_confdir}
+%config(noreplace) %{hp_confdir}/%{name}.cfg
+%config(noreplace) %{_sysconfdir}/logrotate.d/%{name}
+%config(noreplace) %{_sysconfdir}/sysconfig/%{name}
+%{hp_datadir}/*
+%{_initrddir}/%{name}
+%if 0%{?rhel} >= 7
+%{_unitdir}/%{name}.service
+%endif
+%{_sbindir}/%{name}
+%{_bindir}/halog
+%{_mandir}/man1/%{name}.1.gz
+%attr(0755, %{hp_user}, %{hp_group}) %dir %{hp_homedir}
+
+###############################################################################
+
+%changelog
+* Wed Nov 29 2017 Gleb Goncharov <g.goncharov@fun-box.ru> - 1.8.0-0
+- Initial build. 
+


### PR DESCRIPTION
Hello, @andyone 

[HAProxy 1.8 has been released](https://www.haproxy.com/blog/whats-new-haproxy-1-8/), so I decided to build an RPM package. Unfortunately, I could not successfully compiled it with an LibreSSL. I have been tried to write a simple patch to add LibreSSL support, but I stuck in the middle of `openssl-compat.h` implementation of OpenSSL 1.1.0 features.

Anyway, I got BoringSSL library and it was built perfectly. I have not tested this package yet, but in first sight it works fine.