### PR TITLE
Fix Ubuntu release name for Travis CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: bash
 cache: apt
 
 before_install:
-  - echo "deb http://us.archive.ubuntu.com/ubuntu vivid main universe" | sudo tee -a /etc/apt/sources.list 
+  - echo "deb http://us.archive.ubuntu.com/ubuntu xenial main universe" | sudo tee -a /etc/apt/sources.list 
   - sudo apt-get update -qq
   - sudo apt-get install -y rpmlint
 


### PR DESCRIPTION
Hello,

It seems that `us.archive.ubuntu.com` does not serve `vivid` (15.10) anymore. I propose you to use LTS releases only for running CI tests. 