### PR TITLE
Release (2017/12/08)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
   - echo "deb http://us.archive.ubuntu.com/ubuntu xenial main universe" | sudo tee -a /etc/apt/sources.list
   - sudo apt-get update -qq
   - sudo apt-get install -y rpmlint
-  - sudo ln -sf /usr/bin/python2.6 /usr/bin/python2.7
+  - sudo ln -sf /usr/bin/python2.7 /usr/bin/python2.6
 
 script:
   - bash .linter/specs-linter.sh .linter/rpmlint.conf

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ language: bash
 cache: apt
 
 before_install:
-  - echo "deb http://us.archive.ubuntu.com/ubuntu vivid main universe" | sudo tee -a /etc/apt/sources.list 
+  - echo "deb http://us.archive.ubuntu.com/ubuntu xenial main universe" | sudo tee -a /etc/apt/sources.list
   - sudo apt-get update -qq
   - sudo apt-get install -y rpmlint
+  - sudo ln -sf /usr/bin/python2.6 /usr/bin/python2.7
 
 script:
   - bash .linter/specs-linter.sh .linter/rpmlint.conf

--- a/libverto.spec
+++ b/libverto.spec
@@ -208,44 +208,54 @@ rm -rf %{buildroot}
 ###############################################################################
 
 %files
+%defattr(-,root,root)
 %doc AUTHORS ChangeLog COPYING NEWS README
 %{_libdir}/%{name}.so.*
 
 %files devel
+%defattr(-,root,root)
 %{_includedir}/verto.h
 %{_includedir}/verto-module.h
 %{_libdir}/%{name}.so
 %{_libdir}/pkgconfig/%{name}.pc
 
 %files glib
+%defattr(-,root,root)
 %{_libdir}/%{name}-glib.so.*
 
 %files glib-devel
+%defattr(-,root,root)
 %{_includedir}/verto-glib.h
 %{_libdir}/%{name}-glib.so
 %{_libdir}/pkgconfig/%{name}-glib.pc
 
 %files libevent
+%defattr(-,root,root)
 %{_libdir}/%{name}-libevent.so.*
 
 %files libevent-devel
+%defattr(-,root,root)
 %{_includedir}/verto-libevent.h
 %{_libdir}/%{name}-libevent.so
 %{_libdir}/pkgconfig/%{name}-libevent.pc
 
 %files tevent
+%defattr(-,root,root)
 %{_libdir}/%{name}-tevent.so.*
 
 %files tevent-devel
+%defattr(-,root,root)
 %{_includedir}/verto-tevent.h
 %{_libdir}/%{name}-tevent.so
 %{_libdir}/pkgconfig/%{name}-tevent.pc
 
 %if !0%{?rhel}
 %files libev
+%defattr(-,root,root)
 %{_libdir}/%{name}-libev.so.*
 
 %files libev-devel
+%defattr(-,root,root)
 %{_includedir}/verto-libev.h
 %{_libdir}/%{name}-libev.so
 %{_libdir}/pkgconfig/%{name}-libev.pc

--- a/libverto.spec
+++ b/libverto.spec
@@ -3,7 +3,7 @@
 Summary:         Main loop abstraction library
 Name:            libverto
 Version:         0.3.0
-Release:         0%{?dist}
+Release:         1%{?dist}
 License:         MIT
 Group:           Development/Libraries
 URL:             https://github.com/latchset/libverto
@@ -264,5 +264,8 @@ rm -rf %{buildroot}
 ###############################################################################
 
 %changelog
+* Fri Dec 08 2017 Anton Novojilov <andy@essentialkaos.com> - 0.3.0-1
+- Improved spec
+
 * Wed Nov 22 2017 Anton Novojilov <andy@essentialkaos.com> - 0.3.0-0
 - Initial build for kaos-repo

--- a/pgbouncer/SOURCES/pgbouncer.init
+++ b/pgbouncer/SOURCES/pgbouncer.init
@@ -27,7 +27,6 @@ MULTIBOUNCER="/etc/init.d/multibouncer"
 ###############################################################################
 
 kv[prog_name]="pgbouncer"
-kv[search_pattern]="pgbouncer"
 
 kv.readSysconfig
 
@@ -37,7 +36,7 @@ conf_file=${CONF_FILE:-/etc/pgbouncer/pgbouncer.ini}
 log_dir=${LOG_DIR:-/var/log/pgbouncer}
 
 kv[user]="$user"
-
+kv[search_pattern]="$binary"
 kv[pid_file]=$(kv.readProperty "$conf_file" "pidfile")
 
 kv[oom_adj]="$OOM_DISABLE"

--- a/pgbouncer/pgbouncer.spec
+++ b/pgbouncer/pgbouncer.spec
@@ -48,7 +48,7 @@
 Summary:           Lightweight connection pooler for PostgreSQL
 Name:              pgbouncer
 Version:           1.7.2
-Release:           2%{?dist}
+Release:           3%{?dist}
 License:           MIT and BSD
 Group:             Applications/Databases
 URL:               https://pgbouncer.github.io
@@ -181,6 +181,9 @@ fi
 ###############################################################################
 
 %changelog
+* Thu Dec 07 2017 Anton Novojilov <andy@essentialkaos.com> - 1.7.2-3
+- Fixed bug with searching process pid in init script
+
 * Tue Mar 28 2017 Anton Novojilov <andy@essentialkaos.com> - 1.7.2-2
 - Rebuilt with latest version of libevent2
 

--- a/redis/redis.spec
+++ b/redis/redis.spec
@@ -42,7 +42,7 @@
 
 Summary:            A persistent key-value database
 Name:               redis
-Version:            4.0.5
+Version:            4.0.6
 Release:            0%{?dist}
 License:            BSD
 Group:              Applications/Databases
@@ -70,7 +70,7 @@ BuildRequires:      make gcc tcl
 Requires:           %{name}-cli >= %{version}
 Requires:           logrotate
 %if 0%{?rhel} <= 6
-Requires:           kaosv >= 2.10
+Requires:           kaosv >= 2.13
 %endif
 
 %if 0%{?rhel} >= 7
@@ -259,6 +259,9 @@ rm -rf %{buildroot}
 ###############################################################################
 
 %changelog
+* Fri Dec 08 2017 Anton Novojilov <andy@essentialkaos.com> - 4.0.6-0
+- More errors in the fixes for PSYNC2 in Redis 4.0.5 were identified
+
 * Sat Dec 02 2017 Anton Novojilov <andy@essentialkaos.com> - 4.0.5-0
 - Redis 4.0.4 fix for PSYNC2 was broken, causing the slave to crash when
   receiving an RDB file from the master that contained a duplicated Lua script


### PR DESCRIPTION
### Updates
* [x] `redis` updated to 4.0.6

### Bugfixes
* [x] `pgbouncer` Fixed bug with searching process PID in init script
* Fixed TravisCI tests

### Improvements
* [x] `libverto` Added default files permissions