### PR TITLE
Fix typo with PgBouncer systems unit description

### DIFF
--- a/nodejs.spec
+++ b/nodejs.spec
@@ -49,6 +49,7 @@ BuildRequires:      gcc-c++ libstdc++-devel
 
 Provides:           %{name} = %{version}-%{release}
 Provides:           %{shortname} = %{version}-%{release}
+Provides:           %{name}(engine) = %{version}-%{release}
 Provides:           npm = %{version}-%{release}
 
 ################################################################################
@@ -117,5 +118,8 @@ export CXX=clang++
 ################################################################################
 
 %changelog
+* Tue Feb 06 2018 Gleb Goncharov <g.goncharov@fun-box.ru> - 8.9.1-1
+- Add nodejs(engine) provides tag
+
 * Thu Nov 16 2017 Gleb Goncharov <g.goncharov@fun-box.ru> - 8.9.1-0
 - Initial build

--- a/pgbouncer/SOURCES/pgbouncer.service
+++ b/pgbouncer/SOURCES/pgbouncer.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Redis
+Description=PgBouncer
 After=syslog.target network.target
 
 [Service]

--- a/pgbouncer/pgbouncer.spec
+++ b/pgbouncer/pgbouncer.spec
@@ -181,6 +181,9 @@ fi
 ################################################################################
 
 %changelog
+* Tue Feb 06 2018 Gleb Goncharov <g.goncharov@fun-box.ru> - 1.7.2-4
+- Fixed typo with systemd unit description
+
 * Thu Dec 07 2017 Anton Novojilov <andy@essentialkaos.com> - 1.7.2-3
 - Fixed bug with searching process pid in init script
 


### PR DESCRIPTION
I found a typo: systemd tells us `Redis` instead of `PgBouncer` in unit. This PR should fix the mistake.

```
$ systemctl status pgbouncer
   pgbouncer.service - Redis
   Loaded: loaded (/usr/lib/systemd/system/pgbouncer.service; enabled; vendor preset: disabled)
   Active: inactive (dead)

$ systemctl cat pgbouncer
# /usr/lib/systemd/system/pgbouncer.service
[Unit]
Description=Redis
After=syslog.target network.target

[Service]
PIDFile=/var/run/pgbouncer/pgbouncer.pid
ExecStart=/etc/init.d/pgbouncer start
ExecStop=/etc/init.d/pgbouncer stop
ExecReload=/etc/init.d/pgbouncer reload

[Install]
WantedBy=multi-user.target
```