### PR TITLE
Add transmission 2.93

### DIFF
--- a/transmission/SOURCES/transmission-fdlimits.patch
+++ b/transmission/SOURCES/transmission-fdlimits.patch
@@ -1,0 +1,25 @@
+--- libtransmission/fdlimit.c.orig	2018-01-10 20:21:41.933611849 +0100
++++ libtransmission/fdlimit.c	2018-01-10 20:22:02.367013913 +0100
+@@ -365,22 +365,6 @@
+       fileset_construct (&i->fileset, FILE_CACHE_SIZE);
+       session->fdInfo = i;
+ 
+-#ifndef _WIN32
+-      /* set the open-file limit to the largest safe size wrt FD_SETSIZE */
+-      struct rlimit limit;
+-      if (!getrlimit (RLIMIT_NOFILE, &limit))
+-        {
+-          const int old_limit = (int) limit.rlim_cur;
+-          const int new_limit = MIN (limit.rlim_max, FD_SETSIZE);
+-          if (new_limit != old_limit)
+-            {
+-              limit.rlim_cur = new_limit;
+-              setrlimit (RLIMIT_NOFILE, &limit);
+-              getrlimit (RLIMIT_NOFILE, &limit);
+-              tr_logAddInfo ("Changed open file limit from %d to %d", old_limit, (int)limit.rlim_cur);
+-            }
+-        }
+-#endif
+     }
+ }
+ 

--- a/transmission/SOURCES/transmission-gtk.appdata.xml
+++ b/transmission/SOURCES/transmission-gtk.appdata.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2014 Richard Hughes <richard@hughsie.com> -->
+<!--
+BugReportURL: https://forum.transmissionbt.com/viewtopic.php?f=3&t=16443
+SentUpstream: 2014-09-18
+-->
+<application>
+  <id type="desktop">transmission-gtk.desktop</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <description>
+    <p>
+      BitTorrent is a peer-to-peer file-sharing protocol that is commonly used to
+      distribute large amounts of data between multiple users.
+    </p>
+    <p>
+      Transmission is a BitTorrent client with an easy-to-use frontend on top a
+      cross-platform backend.
+      Native frontends are available for OS X and Windows, as well as command line and
+      web frontends.
+    </p>
+    <p>
+      Notable features of Transmission include Local Peer Discovery and Full Encryption,
+      Full encryption, DHTµTP, PEX and Magnet Link support.
+    </p>
+  </description>
+  <url type="homepage">http://www.transmissionbt.com/</url>
+  <screenshots>
+    <screenshot type="default">https://raw.githubusercontent.com/hughsie/fedora-appstream/master/screenshots-extra/transmission-gtk/a.png</screenshot>
+  </screenshots>
+  <!-- FIXME: change this to an upstream email address for spec updates
+  <updatecontact>someone_who_cares@upstream_project.org</updatecontact>
+   -->
+</application>

--- a/transmission/SOURCES/transmission-libsystemd.patch
+++ b/transmission/SOURCES/transmission-libsystemd.patch
@@ -1,0 +1,47 @@
+diff -up ./configure.orig ./configure
+--- ./configure.orig	2016-03-06 23:24:37.116078717 +0300
++++ ./configure	2017-04-13 23:25:44.643463654 +0300
+@@ -19160,12 +19160,12 @@ if test -n "$PKG_CONFIG"; then
+         pkg_cv_SYSTEMD_DAEMON_CFLAGS="$SYSTEMD_DAEMON_CFLAGS"
+     else
+         if test -n "$PKG_CONFIG" && \
+-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libsystemd-daemon\""; } >&5
+-  ($PKG_CONFIG --exists --print-errors "libsystemd-daemon") 2>&5
++    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libsystemd\""; } >&5
++  ($PKG_CONFIG --exists --print-errors "libsystemd") 2>&5
+   ac_status=$?
+   $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+   test $ac_status = 0; }; then
+-  pkg_cv_SYSTEMD_DAEMON_CFLAGS=`$PKG_CONFIG --cflags "libsystemd-daemon" 2>/dev/null`
++  pkg_cv_SYSTEMD_DAEMON_CFLAGS=`$PKG_CONFIG --cflags "libsystemd" 2>/dev/null`
+ else
+   pkg_failed=yes
+ fi
+@@ -19178,12 +19178,12 @@ if test -n "$PKG_CONFIG"; then
+         pkg_cv_SYSTEMD_DAEMON_LIBS="$SYSTEMD_DAEMON_LIBS"
+     else
+         if test -n "$PKG_CONFIG" && \
+-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libsystemd-daemon\""; } >&5
+-  ($PKG_CONFIG --exists --print-errors "libsystemd-daemon") 2>&5
++    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libsystemd\""; } >&5
++  ($PKG_CONFIG --exists --print-errors "libsystemd") 2>&5
+   ac_status=$?
+   $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+   test $ac_status = 0; }; then
+-  pkg_cv_SYSTEMD_DAEMON_LIBS=`$PKG_CONFIG --libs "libsystemd-daemon" 2>/dev/null`
++  pkg_cv_SYSTEMD_DAEMON_LIBS=`$PKG_CONFIG --libs "libsystemd" 2>/dev/null`
+ else
+   pkg_failed=yes
+ fi
+@@ -19202,9 +19202,9 @@ else
+         _pkg_short_errors_supported=no
+ fi
+         if test $_pkg_short_errors_supported = yes; then
+-	        SYSTEMD_DAEMON_PKG_ERRORS=`$PKG_CONFIG --short-errors --errors-to-stdout --print-errors "libsystemd-daemon"`
++	        SYSTEMD_DAEMON_PKG_ERRORS=`$PKG_CONFIG --short-errors --errors-to-stdout --print-errors "libsystemd"`
+         else
+-	        SYSTEMD_DAEMON_PKG_ERRORS=`$PKG_CONFIG --errors-to-stdout --print-errors "libsystemd-daemon"`
++	        SYSTEMD_DAEMON_PKG_ERRORS=`$PKG_CONFIG --errors-to-stdout --print-errors "libsystemd"`
+         fi
+ 	# Put the nasty error message in config.log where it belongs
+ 	echo "$SYSTEMD_DAEMON_PKG_ERRORS" >&5

--- a/transmission/transmission.spec
+++ b/transmission/transmission.spec
@@ -229,10 +229,12 @@ fi
 ################################################################################
 
 %files
+%defattr(-,root,root,-)
 
 %files common
 %license COPYING
 %doc AUTHORS NEWS README
+%defattr(-,root,root,-)
 %{_bindir}/%{name}-remote
 %{_bindir}/%{name}-create
 %{_bindir}/%{name}-edit
@@ -246,22 +248,26 @@ fi
 %doc %{_mandir}/man1/%{name}-show*
 
 %files cli
+%defattr(-,root,root,-)
 %{_bindir}/%{name}-cli
 %doc %{_mandir}/man1/%{name}-cli*
 
 %files daemon
+%defattr(-,root,root,-)
 %{_bindir}/%{name}-daemon
 %{_unitdir}/%{name}-daemon.service
 %attr(-,%{service_user},%{service_group})%{service_home}
 %doc %{_mandir}/man1/%{name}-daemon*
 
 %files gtk -f %{name}-gtk.lang
+%defattr(-,root,root,-)
 %{_bindir}/%{name}-gtk
 %{_datadir}/appdata/%{name}-gtk.appdata.xml
 %{_datadir}/applications/%{name}-gtk.desktop
 %doc %{_mandir}/man1/%{name}-gtk.*
 
 %files qt
+%defattr(-,root,root,-)
 %{_bindir}/%{name}-qt
 %{_datadir}/applications/%{name}-qt.desktop
 %doc %{_mandir}/man1/%{name}-qt.*

--- a/transmission/transmission.spec
+++ b/transmission/transmission.spec
@@ -232,9 +232,9 @@ fi
 %defattr(-,root,root,-)
 
 %files common
+%defattr(-,root,root,-)
 %license COPYING
 %doc AUTHORS NEWS README
-%defattr(-,root,root,-)
 %{_bindir}/%{name}-remote
 %{_bindir}/%{name}-create
 %{_bindir}/%{name}-edit

--- a/transmission/transmission.spec
+++ b/transmission/transmission.spec
@@ -1,0 +1,273 @@
+################################################################################
+
+%define _hardened_build   1
+
+################################################################################
+
+%define _posixroot        /
+%define _root             /root
+%define _bin              /bin
+%define _sbin             /sbin
+%define _srv              /srv
+%define _home             /home
+%define _lib32            %{_posixroot}lib
+%define _lib64            %{_posixroot}lib64
+%define _libdir32         %{_prefix}%{_lib32}
+%define _libdir64         %{_prefix}%{_lib64}
+%define _logdir           %{_localstatedir}/log
+%define _rundir           %{_localstatedir}/run
+%define _lockdir          %{_localstatedir}/lock/subsys
+%define _cachedir         %{_localstatedir}/cache
+%define _spooldir         %{_localstatedir}/spool
+%define _crondir          %{_sysconfdir}/cron.d
+%define _loc_prefix       %{_prefix}/local
+%define _loc_exec_prefix  %{_loc_prefix}
+%define _loc_bindir       %{_loc_exec_prefix}/bin
+%define _loc_libdir       %{_loc_exec_prefix}/%{_lib}
+%define _loc_libdir32     %{_loc_exec_prefix}/%{_lib32}
+%define _loc_libdir64     %{_loc_exec_prefix}/%{_lib64}
+%define _loc_libexecdir   %{_loc_exec_prefix}/libexec
+%define _loc_sbindir      %{_loc_exec_prefix}/sbin
+%define _loc_bindir       %{_loc_exec_prefix}/bin
+%define _loc_datarootdir  %{_loc_prefix}/share
+%define _loc_includedir   %{_loc_prefix}/include
+%define _rpmstatedir      %{_sharedstatedir}/rpm-state
+%define _pkgconfigdir     %{_libdir}/pkgconfig
+
+%define __service         %{_sbin}/service
+%define __chkconfig       %{_sbin}/chkconfig
+%define __ldconfig        %{_sbin}/ldconfig
+%define __useradd         %{_sbindir}/useradd
+%define __groupadd        %{_sbindir}/groupadd
+%define __getent          %{_bindir}/getent
+%define __systemctl       %{_bindir}/systemctl
+
+################################################################################
+
+%define service_user      transmission
+%define service_group     transmission
+%define service_name      %{name}
+%define service_home      %{_sharedstatedir}/%{name}
+
+################################################################################
+
+Summary:            A lightweight GTK+ BitTorrent client
+Name:               transmission
+Version:            2.93
+Release:            0%{?dist}
+License:            MIT and GPLv2
+Group:              Applications/Internet
+URL:                http://www.transmissionbt.com
+
+Source0:            https://github.com/%{name}/%{name}-releases/raw/master/%{name}-%{version}.tar.xz
+Source1:            %{name}-gtk.appdata.xml
+
+Patch0:             %{name}-libsystemd.patch
+Patch1:             %{name}-fdlimits.patch
+
+BuildRoot:          %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+
+BuildRequires:      gcc-c++ openssl-devel >= 1.1.0 glib2-devel >= 2.32.0
+BuildRequires:      gtk3-devel >= 3.2.0 libnotify-devel >= 0.4.3
+BuildRequires:      libcanberra-devel libcurl-devel >= 7.16.3
+BuildRequires:      dbus-glib-devel >= 0.70 libevent-devel >= 2.0.10
+BuildRequires:      desktop-file-utils gettext intltool qt5-qtbase-devel
+BuildRequires:      systemd-devel libnatpmp-devel >= 20150609-1
+
+Requires:           transmission-gtk
+
+################################################################################
+
+%description
+Transmission is a free, lightweight BitTorrent client. It features a
+simple, intuitive interface on top on an efficient, cross-platform
+back-end.
+
+################################################################################
+
+%package common
+Summary:            Transmission common files
+Group:              Applications/Internet
+
+Conflicts:          %{name} < 1.80-0.3.b4
+
+%description common
+Common files for Transmission BitTorrent client sub-packages. It includes
+the web user interface, icons and transmission-remote, transmission-create,
+transmission-edit, transmission-show utilities.
+
+################################################################################
+
+%package cli
+Summary:            Transmission command line implementation
+Group:              Applications/Internet
+Requires:           transmission-common
+
+%description cli
+Command line version of Transmission BitTorrent client.
+
+################################################################################
+
+%package daemon
+Summary:            Transmission daemon
+Group:              Applications/Internet
+Requires:           transmission-common
+
+BuildRequires:      systemd
+
+Requires(pre):      shadow-utils
+Requires(post):     systemd
+Requires(preun):    systemd
+Requires(postun):   systemd
+
+%description daemon
+Transmission BitTorrent client daemon.
+
+################################################################################
+
+%package gtk
+Summary:            Transmission GTK interface
+Group:              Applications/Internet
+Requires:           transmission-common
+
+%description gtk
+GTK graphical interface of Transmission BitTorrent client.
+
+################################################################################
+
+%package qt
+Summary:            Transmission Qt interface
+Group:              Applications/Internet
+Requires:           transmission-common
+
+%description qt
+Qt graphical interface of Transmission BitTorrent client.
+
+################################################################################
+
+%prep
+%setup -q
+
+%patch0 -p0
+%patch1 -p0
+
+# fix icon location for Transmission Qt
+sed -i 's|Icon=%{name}-qt|Icon=%{name}|g' qt/%{name}-qt.desktop
+
+# convert to UTF encoding
+iconv --from=ISO-8859-1 --to=UTF-8 AUTHORS > AUTHORS.new
+mv AUTHORS.new AUTHORS
+
+iconv --from=ISO-8859-1 --to=UTF-8 NEWS > NEWS.new
+mv NEWS.new NEWS
+
+%build
+CXXFLAGS="%{optflags} -fPIC"
+
+%configure --disable-static --enable-utp --enable-daemon --with-systemd-daemon \
+           --enable-nls --enable-cli --enable-daemon \
+           --enable-external-natpmp
+
+%{__make} %{?_smp_mflags}
+
+pushd qt
+  %{qmake_qt5} qtr.pro
+  %{__make} %{?_smp_mflags}
+popd
+
+%check
+%{__make} %{?_smp_mflags} check
+
+%install
+%{__rm} -rf %{buildroot}
+
+%{make_install}
+%{make_install} INSTALL_ROOT=%{buildroot}%{_prefix} -C qt
+
+%find_lang %{name}-gtk
+
+desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}-gtk.desktop
+desktop-file-install \
+                --dir=%{buildroot}%{_datadir}/applications/  \
+                  qt/%{name}-qt.desktop
+
+install -dm 0755 %{buildroot}%{_unitdir}
+install -dm 0755 %{buildroot}%{_sharedstatedir}/%{name}
+install -dm 0755 %{buildroot}%{_datadir}/appdata
+
+install -pm 0644 daemon/%{name}-daemon.service  %{buildroot}%{_unitdir}/
+install -pm 0644 %{SOURCE1} %{buildroot}%{_datadir}/appdata/%{name}-gtk.appdata.xml
+
+%clean
+%{__rm} -rf %{buildroot}
+
+################################################################################
+
+%pre daemon
+if [[ $1 -eq 1 ]] ; then
+  %{__getent} group %{service_group} >/dev/null || %{__groupadd} -o -r %{service_group}
+  %{__getent} passwd %{service_user} >/dev/null || \
+    %{__useradd} -M -n -o -r -d %{service_home} \
+        -s /sbin/nologin -c "transmission daemon-account" %{service_user}
+fi
+
+%post daemon
+if [[ $1 -eq 1 ]] ; then
+  %{__systemctl} daemon-reload %{name}-daemon.service &>/dev/null || :
+  %{__systemctl} preset %{name}-daemon.service &>/dev/null || :
+fi
+
+%preun daemon
+if [[ $1 -eq 0 ]] ; then
+  %{__systemctl} --no-reload disable %{name}-daemon.service &>/dev/null || :
+  %{__systemctl} stop %{name}-daemon.service &>/dev/null || :
+fi
+
+%postun daemon
+%systemd_postun_with_restart %{name}-daemon.service
+
+################################################################################
+
+%files
+
+%files common
+%license COPYING
+%doc AUTHORS NEWS README
+%{_bindir}/transmission-remote
+%{_bindir}/transmission-create
+%{_bindir}/transmission-edit
+%{_bindir}/transmission-show
+%{_datadir}/transmission/
+%{_datadir}/pixmaps/*
+%{_datadir}/icons/hicolor/*/apps/transmission.*
+%doc %{_mandir}/man1/transmission-remote*
+%doc %{_mandir}/man1/transmission-create*
+%doc %{_mandir}/man1/transmission-edit*
+%doc %{_mandir}/man1/transmission-show*
+
+%files cli
+%{_bindir}/transmission-cli
+%doc %{_mandir}/man1/transmission-cli*
+
+%files daemon
+%{_bindir}/transmission-daemon
+%{_unitdir}/transmission-daemon.service
+%attr(-,transmission, transmission)%{_sharedstatedir}/transmission/
+%doc %{_mandir}/man1/transmission-daemon*
+
+%files gtk -f %{name}-gtk.lang
+%{_bindir}/transmission-gtk
+%{_datadir}/appdata/%{name}-gtk.appdata.xml
+%{_datadir}/applications/transmission-gtk.desktop
+%doc %{_mandir}/man1/transmission-gtk.*
+
+%files qt
+%{_bindir}/transmission-qt
+%{_datadir}/applications/transmission-qt.desktop
+%doc %{_mandir}/man1/transmission-qt.*
+
+################################################################################
+
+%changelog
+* Sun Feb 11 2018 Gleb Goncharov <inbox@gongled.ru> - 2.93-0
+- Initial build.

--- a/transmission/transmission.spec
+++ b/transmission/transmission.spec
@@ -233,38 +233,38 @@ fi
 %files common
 %license COPYING
 %doc AUTHORS NEWS README
-%{_bindir}/transmission-remote
-%{_bindir}/transmission-create
-%{_bindir}/transmission-edit
-%{_bindir}/transmission-show
-%{_datadir}/transmission/
+%{_bindir}/%{name}-remote
+%{_bindir}/%{name}-create
+%{_bindir}/%{name}-edit
+%{_bindir}/%{name}-show
+%{_datadir}/%{name}/
 %{_datadir}/pixmaps/*
-%{_datadir}/icons/hicolor/*/apps/transmission.*
-%doc %{_mandir}/man1/transmission-remote*
-%doc %{_mandir}/man1/transmission-create*
-%doc %{_mandir}/man1/transmission-edit*
-%doc %{_mandir}/man1/transmission-show*
+%{_datadir}/icons/hicolor/*/apps/%{name}.*
+%doc %{_mandir}/man1/%{name}-remote*
+%doc %{_mandir}/man1/%{name}-create*
+%doc %{_mandir}/man1/%{name}-edit*
+%doc %{_mandir}/man1/%{name}-show*
 
 %files cli
-%{_bindir}/transmission-cli
-%doc %{_mandir}/man1/transmission-cli*
+%{_bindir}/%{name}-cli
+%doc %{_mandir}/man1/%{name}-cli*
 
 %files daemon
-%{_bindir}/transmission-daemon
-%{_unitdir}/transmission-daemon.service
-%attr(-,transmission, transmission)%{_sharedstatedir}/transmission/
-%doc %{_mandir}/man1/transmission-daemon*
+%{_bindir}/%{name}-daemon
+%{_unitdir}/%{name}-daemon.service
+%attr(-,%{service_user},%{service_group})%{service_home}
+%doc %{_mandir}/man1/%{name}-daemon*
 
 %files gtk -f %{name}-gtk.lang
-%{_bindir}/transmission-gtk
+%{_bindir}/%{name}-gtk
 %{_datadir}/appdata/%{name}-gtk.appdata.xml
-%{_datadir}/applications/transmission-gtk.desktop
-%doc %{_mandir}/man1/transmission-gtk.*
+%{_datadir}/applications/%{name}-gtk.desktop
+%doc %{_mandir}/man1/%{name}-gtk.*
 
 %files qt
-%{_bindir}/transmission-qt
-%{_datadir}/applications/transmission-qt.desktop
-%doc %{_mandir}/man1/transmission-qt.*
+%{_bindir}/%{name}-qt
+%{_datadir}/applications/%{name}-qt.desktop
+%doc %{_mandir}/man1/%{name}-qt.*
 
 ################################################################################
 


### PR DESCRIPTION
Hello,

Transmission is a cross platform BitTorrent client. Fedora Package maintainers from EPEL uses `libevent` with 2.0.x from the base repository. Unfortunately, I cannot continue use Transmission at the same time with EK repository because of `libevent` 2.1.x dependency. So I decided to open a pull request.