### PR TITLE
Add Prometheus 2.2.1

### DIFF
--- a/prometheus/SOURCES/prometheus.init
+++ b/prometheus/SOURCES/prometheus.init
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+###############################################################################
+
+# prometheus        Monitoring system and time series database 
+
+# chkconfig: - 85 15
+# processname: prometheus
+# config: /etc/sysconfig/prometheus
+# pidfile: /var/run/prometheus.pid
+# description: Monitoring system and time series database
+
+### BEGIN INIT INFO
+# Provides: prometheus
+# Required-Start: $local_fs $remote_fs $network
+# Required-Stop: $local_fs $remote_fs $network
+# Default-Start: 2 3 4 5
+# Default-Stop: 0 1 6
+# Short-Description: start and stop prometheus
+
+###############################################################################
+
+source /etc/init.d/kaosv
+
+###############################################################################
+
+kv[prog_name]="prometheus"
+
+kv.readSysconfig
+
+binary="${BINARY:-/usr/bin/prometheus}"
+user="${USER:-prometheus}"
+options="${PROMETHEUS_OPTS}"
+
+libraries_path="/usr/share/prometheus/console_libraries"
+templates_path="/usr/share/prometheus/consoles"
+
+kv[user]="$user"
+kv[pid_dir]="/var/run/prometheus"
+kv[search_pattern]="$binary"
+
+###############################################################################
+
+kv.addCommand "reload" "Reload configuration files" "reload"
+
+kv.addHandler "start" "startServiceHandler"
+kv.addHandler "stop"  "stopServiceHandler"
+kv.addHandler "start" "postStartServiceHandler" "post"
+
+###############################################################################
+
+reload() {
+  if ! kv.statusIs "$STATUS_WORKS" ; then
+    kv.show "You must start service before this command usage." $BROWN
+    return $ACTION_ERROR
+  fi
+
+  kv.showProcessMessage "Reloading config for ${kv[prog_name]}"
+
+  reloadConfigHandler
+
+  local status=$?
+
+  kv.showStatusMessage "$status"
+
+  return $status
+}
+
+###############################################################################
+
+startServiceHandler() {
+  kv.daemonize "$binary" "--web.console.libraries=$libraries_path" "--web.console.templates=$templates_path" "$options"
+
+  [[ $? -ne 0 ]] && return $ACTION_ERROR
+
+  kv.getStartStatus
+
+  return $?
+}
+
+stopServiceHandler() {
+  local pid=`kv.getPid`
+
+  kv.sendSignal "$SIGNAL_TERM"
+
+  if kv.getStopStatus ; then
+    return $ACTION_OK
+  else
+    kv.killProcess "$pid"
+    [[ $? -eq 0 ]] && return $ACTION_FORCED
+  fi
+}
+
+postStartServiceHandler() {
+  if kv.statusIs "$STATUS_STOPPED" ; then
+    kv.checkSELinux
+    return $?
+  fi
+}
+
+reloadConfigHandler() {
+  kv.sendSignal $SIGNAL_HUP
+  return $ACTION_OK
+}
+
+###############################################################################
+
+kv.go $@
+

--- a/prometheus/SOURCES/prometheus.init
+++ b/prometheus/SOURCES/prometheus.init
@@ -37,6 +37,7 @@ templates_path="/usr/share/prometheus/consoles"
 
 kv[user]="$user"
 kv[pid_dir]="/var/run/prometheus"
+kv[log]="/var/log/prometheus/prometheus.log"
 kv[search_pattern]="$binary"
 
 ###############################################################################

--- a/prometheus/SOURCES/prometheus.logrotate
+++ b/prometheus/SOURCES/prometheus.logrotate
@@ -1,0 +1,9 @@
+/var/log/prometheus/*.log {
+    weekly
+    rotate 8
+    copytruncate
+    delaycompress
+    compress
+    notifempty
+    missingok
+}

--- a/prometheus/SOURCES/prometheus.service
+++ b/prometheus/SOURCES/prometheus.service
@@ -8,6 +8,8 @@ After=network.target
 [Service]
 EnvironmentFile=-/etc/sysconfig/prometheus
 User=prometheus
+StandardOutput=/var/log/prometheus/prometheus.log
+StandardError=/var/log/prometheus/prometheus.log
 ExecStart=/usr/bin/prometheus \
           --web.console.libraries=/usr/share/prometheus/console_libraries \
           --web.console.templates=/usr/share/prometheus/consoles \

--- a/prometheus/SOURCES/prometheus.service
+++ b/prometheus/SOURCES/prometheus.service
@@ -1,0 +1,19 @@
+# -*- mode: conf -*-
+
+[Unit]
+Description=The Prometheus monitoring system and time series database.
+Documentation=https://prometheus.io
+After=network.target
+
+[Service]
+EnvironmentFile=-/etc/sysconfig/prometheus
+User=prometheus
+ExecStart=/usr/bin/prometheus \
+          --web.console.libraries=/usr/share/prometheus/console_libraries \
+          --web.console.templates=/usr/share/prometheus/consoles \
+          $PROMETHEUS_OPTS
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/prometheus/SOURCES/prometheus.sysconfig
+++ b/prometheus/SOURCES/prometheus.sysconfig
@@ -1,0 +1,1 @@
+PROMETHEUS_OPTS='--config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=/var/lib/prometheus/data'

--- a/prometheus/prometheus.spec
+++ b/prometheus/prometheus.spec
@@ -1,0 +1,201 @@
+################################################################################
+
+%define debug_package  %{nil}
+
+################################################################################
+
+%define _posixroot        /
+%define _root             /root
+%define _bin              /bin
+%define _sbin             /sbin
+%define _srv              /srv
+%define _home             /home
+%define _lib32            %{_posixroot}lib
+%define _lib64            %{_posixroot}lib64
+%define _libdir32         %{_prefix}%{_lib32}
+%define _libdir64         %{_prefix}%{_lib64}
+%define _logdir           %{_localstatedir}/log
+%define _rundir           %{_localstatedir}/run
+%define _lockdir          %{_localstatedir}/lock
+%define _cachedir         %{_localstatedir}/cache
+%define _loc_prefix       %{_prefix}/local
+%define _loc_exec_prefix  %{_loc_prefix}
+%define _loc_bindir       %{_loc_exec_prefix}/bin
+%define _loc_libdir       %{_loc_exec_prefix}/%{_lib}
+%define _loc_libdir32     %{_loc_exec_prefix}/%{_lib32}
+%define _loc_libdir64     %{_loc_exec_prefix}/%{_lib64}
+%define _loc_libexecdir   %{_loc_exec_prefix}/libexec
+%define _loc_sbindir      %{_loc_exec_prefix}/sbin
+%define _loc_bindir       %{_loc_exec_prefix}/bin
+%define _loc_datarootdir  %{_loc_prefix}/share
+%define _loc_includedir   %{_loc_prefix}/include
+%define _rpmstatedir      %{_sharedstatedir}/rpm-state
+
+%define __ln              %{_bin}/ln
+%define __touch           %{_bin}/touch
+%define __service         %{_sbin}/service
+%define __chkconfig       %{_sbin}/chkconfig
+%define __useradd         %{_sbindir}/useradd
+%define __groupadd        %{_sbindir}/groupadd
+%define __getent          %{_bindir}/getent
+%define __systemctl       %{_bindir}/systemctl
+
+################################################################################
+
+%define service_user   prometheus
+%define service_group  prometheus
+
+################################################################################
+
+Summary:          Monitoring system and time series database
+Name:             prometheus
+Version:          2.2.1
+Release:          0%{?dist}
+Group:            Applications/Databases
+License:          ASL 2.0
+URL:              https://prometheus.io
+
+Source0:          https://github.com/%{name}/%{name}/archive/v%{version}.tar.gz
+Source1:          %{name}.service
+Source2:          %{name}.init
+Source3:          %{name}.sysconfig
+
+BuildRoot:        %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+
+BuildRequires:    golang >= 1.9
+
+%if 0%{?rhel} >= 7
+Requires:         systemd
+
+Requires(pre):    shadow-utils
+Requires(post):   systemd
+Requires(preun):  systemd
+Requires(postun): systemd
+%else
+Requires:         initscripts kaosv >= 2.15
+
+Requires(pre):    shadow-utils
+Requires(post):   %{__chkconfig}
+Requires(preun):  %{__chkconfig} %{__service}
+Requires(postun): %{__service}
+%endif
+
+Conflicts:       prometheus < 2.0
+
+Provides:        %{name} = %{version}-%{release}
+
+################################################################################
+
+%description
+
+Prometheus is a systems and service monitoring system. It collects metrics from
+configured targets at given intervals, evaluates rule expressions, displays the
+results, and can trigger alerts if some condition is observed to be true.
+
+################################################################################
+
+%prep
+%setup -qn %{name}-%{version}
+
+%build
+export GOPATH=$(pwd)
+go get github.com/%{name}/%{name}/cmd/...
+
+%{__make} %{?_smp_mflags} build
+
+%install
+rm -rf %{buildroot}
+
+install -dm 0755 %{buildroot}%{_bindir}
+install -dm 0755 %{buildroot}%{_sysconfdir}/%{name}
+install -dm 0755 %{buildroot}%{_sysconfdir}/sysconfig
+install -dm 0755 %{buildroot}%{_datarootdir}/%{name}/consoles
+install -dm 0755 %{buildroot}%{_datarootdir}/%{name}/console_libraries
+install -dm 0755 %{buildroot}%{_sharedstatedir}/%{name}
+
+%if 0%{?rhel} >= 7
+    install -dm 0755 %{buildroot}%{_unitdir}
+%else
+    install -dm 0755 %{buildroot}%{_initrddir}
+%endif
+
+install -pm 755 prometheus %{buildroot}%{_bindir}/%{name}
+install -pm 755 promtool %{buildroot}%{_bindir}/promtool
+
+for dir in consoles console_libraries; do
+  for file in ${dir}/*; do
+    install -pm 0644 ${file} %{buildroot}%{_datarootdir}/%{name}/${file}
+  done
+done
+
+install -pm 0644 documentation/examples/%{name}.yml %{buildroot}%{_sysconfdir}/%{name}/%{name}.yml
+install -pm 0644 %{SOURCE3} %{buildroot}%{_sysconfdir}/sysconfig/%{name}
+
+%if 0%{?rhel} >= 7
+    install -pm 0644 %{SOURCE1} %{buildroot}%{_unitdir}/%{name}.service
+%else
+    install -pm 0755 %{SOURCE2} %{buildroot}%{_initrddir}/%{name}
+%endif
+
+%check
+
+%clean
+rm -rf %{buildroot}
+
+################################################################################
+
+%pre
+%{__getent} group %{service_group} >/dev/null || %{__groupadd} -r %{service_group}
+%{__getent} passwd %{service_user} >/dev/null || %{__useradd} -r \
+    -g %{service_group} -d %{_sharedstatedir}/%{name} \
+    -s /sbin/nologin %{service_user}
+
+%post
+if [[ $1 -eq 1 ]] ; then
+%if 0%{?rhel} >= 7
+  %{__systemctl} enable %{name}.service &>/dev/null || :
+%else
+  %{__chkconfig} --add %{name} &>/dev/null || :
+%endif
+fi
+
+%preun
+if [[ $1 -eq 0 ]] ; then
+%if 0%{?rhel} >= 7
+  %{__systemctl} --no-reload disable %{name}.service &>/dev/null || :
+  %{__systemctl} stop %{name}.service &>/dev/null || :
+%else
+  %{__service} %{name} stop &>/dev/null || :
+  %{__chkconfig} --del %{name} &>/dev/null || :
+%endif
+fi
+
+%postun
+%if 0%{?rhel} >= 7
+if [[ $1 -ge 1 ]] ; then
+  %{__systemctl} daemon-reload &>/dev/null || :
+fi
+%endif
+
+################################################################################
+
+%files
+%defattr(-,root,root,-)
+%{_bindir}/%{name}
+%{_bindir}/promtool
+%config(noreplace) %{_sysconfdir}/%{name}/%{name}.yml
+%{_datarootdir}/%{name}
+%if 0%{?rhel} >= 7
+    %{_unitdir}/%{name}.service
+%else
+    %{_initrddir}/%{name}
+%endif
+%config(noreplace) %{_sysconfdir}/sysconfig/%{name}
+%attr(755, %{service_user}, %{service_group}) %{_sharedstatedir}/%{name}
+
+################################################################################
+
+%changelog
+* Tue Mar 27 2018 Gleb Goncharov <g.goncharov@fun-box.ru> - 2.2.1-0
+- Initial build
+

--- a/prometheus/prometheus.spec
+++ b/prometheus/prometheus.spec
@@ -112,6 +112,7 @@ install -dm 0755 %{buildroot}%{_sysconfdir}/sysconfig
 install -dm 0755 %{buildroot}%{_datarootdir}/%{name}/consoles
 install -dm 0755 %{buildroot}%{_datarootdir}/%{name}/console_libraries
 install -dm 0755 %{buildroot}%{_sharedstatedir}/%{name}
+install -dm 0755 %{buildroot}%{_logdir}/%{name}
 
 %if 0%{?rhel} >= 7
     install -dm 0755 %{buildroot}%{_unitdir}
@@ -191,6 +192,7 @@ fi
     %{_initrddir}/%{name}
 %endif
 %config(noreplace) %{_sysconfdir}/sysconfig/%{name}
+%attr(755, %{service_user}, %{service_group}) %{_logdir}/%{name}
 %attr(755, %{service_user}, %{service_group}) %{_sharedstatedir}/%{name}
 
 ################################################################################

--- a/prometheus/prometheus.spec
+++ b/prometheus/prometheus.spec
@@ -87,7 +87,6 @@ Provides:        %{name} = %{version}-%{release}
 ################################################################################
 
 %description
-
 Prometheus is a systems and service monitoring system. It collects metrics from
 configured targets at given intervals, evaluates rule expressions, displays the
 results, and can trigger alerts if some condition is observed to be true.

--- a/prometheus/prometheus.spec
+++ b/prometheus/prometheus.spec
@@ -62,7 +62,7 @@ Source3:          %{name}.sysconfig
 
 BuildRoot:        %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
-BuildRequires:    golang >= 1.9
+BuildRequires:    golang >= 1.10
 
 %if 0%{?rhel} >= 7
 Requires:         systemd

--- a/prometheus/prometheus.spec
+++ b/prometheus/prometheus.spec
@@ -59,10 +59,13 @@ Source0:          https://github.com/%{name}/%{name}/archive/v%{version}.tar.gz
 Source1:          %{name}.service
 Source2:          %{name}.init
 Source3:          %{name}.sysconfig
+Source4:          %{name}.logrotate
 
 BuildRoot:        %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires:    golang >= 1.10
+
+Requires:         logrotate
 
 %if 0%{?rhel} >= 7
 Requires:         systemd
@@ -130,6 +133,7 @@ done
 
 install -pm 0644 documentation/examples/%{name}.yml %{buildroot}%{_sysconfdir}/%{name}/%{name}.yml
 install -pm 0644 %{SOURCE3} %{buildroot}%{_sysconfdir}/sysconfig/%{name}
+install -pm 0644 %{SOURCE4} %{buildroot}%{_sysconfdir}/logrotate.d/%{name}
 
 %if 0%{?rhel} >= 7
     install -pm 0644 %{SOURCE1} %{buildroot}%{_unitdir}/%{name}.service
@@ -181,6 +185,7 @@ fi
 %defattr(-,root,root,-)
 %{_bindir}/%{name}
 %{_bindir}/promtool
+%config(noreplace) %{_sysconfdir}/logrotate.d/%{name}
 %config(noreplace) %{_sysconfdir}/%{name}/%{name}.yml
 %{_datarootdir}/%{name}
 %if 0%{?rhel} >= 7

--- a/prometheus/prometheus.spec
+++ b/prometheus/prometheus.spec
@@ -189,9 +189,9 @@ fi
 %config(noreplace) %{_sysconfdir}/%{name}/%{name}.yml
 %{_datarootdir}/%{name}
 %if 0%{?rhel} >= 7
-    %{_unitdir}/%{name}.service
+%{_unitdir}/%{name}.service
 %else
-    %{_initrddir}/%{name}
+%{_initrddir}/%{name}
 %endif
 %config(noreplace) %{_sysconfdir}/sysconfig/%{name}
 %attr(755, %{service_user}, %{service_group}) %{_logdir}/%{name}

--- a/prometheus/prometheus.spec
+++ b/prometheus/prometheus.spec
@@ -80,9 +80,9 @@ Requires(preun):  %{__chkconfig} %{__service}
 Requires(postun): %{__service}
 %endif
 
-Conflicts:       prometheus < 2.0
+Conflicts:        prometheus < 2.0
 
-Provides:        %{name} = %{version}-%{release}
+Provides:         %{name} = %{version}-%{release}
 
 ################################################################################
 

--- a/prometheus/prometheus.spec
+++ b/prometheus/prometheus.spec
@@ -138,8 +138,6 @@ install -pm 0644 %{SOURCE3} %{buildroot}%{_sysconfdir}/sysconfig/%{name}
     install -pm 0755 %{SOURCE2} %{buildroot}%{_initrddir}/%{name}
 %endif
 
-%check
-
 %clean
 rm -rf %{buildroot}
 

--- a/prometheus/promu.spec
+++ b/prometheus/promu.spec
@@ -1,0 +1,107 @@
+################################################################################
+
+%define debug_package  %{nil}
+
+################################################################################
+
+%define _posixroot        /
+%define _root             /root
+%define _bin              /bin
+%define _sbin             /sbin
+%define _srv              /srv
+%define _home             /home
+%define _lib32            %{_posixroot}lib
+%define _lib64            %{_posixroot}lib64
+%define _libdir32         %{_prefix}%{_lib32}
+%define _libdir64         %{_prefix}%{_lib64}
+%define _logdir           %{_localstatedir}/log
+%define _rundir           %{_localstatedir}/run
+%define _lockdir          %{_localstatedir}/lock
+%define _cachedir         %{_localstatedir}/cache
+%define _loc_prefix       %{_prefix}/local
+%define _loc_exec_prefix  %{_loc_prefix}
+%define _loc_bindir       %{_loc_exec_prefix}/bin
+%define _loc_libdir       %{_loc_exec_prefix}/%{_lib}
+%define _loc_libdir32     %{_loc_exec_prefix}/%{_lib32}
+%define _loc_libdir64     %{_loc_exec_prefix}/%{_lib64}
+%define _loc_libexecdir   %{_loc_exec_prefix}/libexec
+%define _loc_sbindir      %{_loc_exec_prefix}/sbin
+%define _loc_bindir       %{_loc_exec_prefix}/bin
+%define _loc_datarootdir  %{_loc_prefix}/share
+%define _loc_includedir   %{_loc_prefix}/include
+%define _rpmstatedir      %{_sharedstatedir}/rpm-state
+
+%define __ln              %{_bin}/ln
+%define __touch           %{_bin}/touch
+%define __service         %{_sbin}/service
+%define __chkconfig       %{_sbin}/chkconfig
+%define __useradd         %{_sbindir}/useradd
+%define __groupadd        %{_sbindir}/groupadd
+%define __getent          %{_bindir}/getent
+%define __systemctl       %{_bindir}/systemctl
+
+################################################################################
+
+Summary:          Prometheus Utility Tool
+Name:             promu
+Version:          0.1.0
+Release:          0%{?dist}
+Group:            Development/Tools
+License:          ASL 2.0
+URL:              https://prometheus.io
+
+Source0:          https://github.com/prometheus/%{name}/archive/v%{version}.tar.gz
+
+BuildRoot:        %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+
+BuildRequires:    golang >= 1.10
+
+Provides:         %{name} = %{version}-%{release}
+
+################################################################################
+
+%description
+Promu is the utility tool for Prometheus projects. This tool is part of
+reflexion about Prometheus Component Builds.
+
+################################################################################
+
+%prep
+%setup -q -n %{name}-%{version}
+
+mkdir -p .src/github.com/prometheus/%{name}
+mv * .src/github.com/prometheus/%{name}/
+mv .promu.yml .src/github.com/prometheus/%{name}/
+mv .src src
+
+%build
+export GOPATH=$(pwd)
+export CGO_ENABLED=0
+
+pushd src/github.com/prometheus/%{name}
+    %{__make} %{?_smp_mflags} build
+popd
+
+%install
+rm -rf %{buildroot}
+
+install -dm 0755 %{buildroot}%{_bin}
+
+install -pm 0755 src/github.com/prometheus/%{name}/%{name} \
+        %{buildroot}%{_bin}/%{name}
+
+%clean
+rm -rf %{buildroot}
+
+################################################################################
+
+%files
+%defattr(-,root,root,-)
+%{_bin}/%{name}
+
+################################################################################
+
+%changelog
+* Wed Mar 28 2018 Gleb Goncharov <g.goncharov@fun-box.ru> - 0.1.0-0
+- Initial build
+

--- a/prometheus/promu.spec
+++ b/prometheus/promu.spec
@@ -76,7 +76,6 @@ mv .src src
 
 %build
 export GOPATH=$(pwd)
-export CGO_ENABLED=0
 
 pushd src/github.com/prometheus/%{name}
     %{__make} %{?_smp_mflags} build


### PR DESCRIPTION
Hello, @andyone.

I ask you to pack Prometheus 2.2.1 and publish it into EK repository. I do not know how to deal with logging directory: it writes only to stdout/stderr and does not have any options to output logging to file without redirects using UNIX pipe. I have checked RPM package locally on CentOS 6 and CentOS 7 and it looks fine, but with no logging at all.