### PR TITLE
Update Erlang 20 and 21 with patch version

### DIFF
--- a/specs/erlangR20.spec
+++ b/specs/erlangR20.spec
@@ -42,6 +42,10 @@
 %define eprefix           %{_prefix}%{_lib32}
 %define ver_maj           20
 %define ver_min           3
+%define ver_patch         8.3
+%define ver_suffix        3.8.3
+%define ver_string        20.%{ver_suffix}
+
 %define realname          erlang
 
 %define libre_ver         2.6.4
@@ -50,13 +54,13 @@
 
 Summary:           General-purpose programming language and runtime environment
 Name:              %{realname}%{ver_maj}
-Version:           %{ver_min}
-Release:           1%{?dist}
+Version:           %{ver_suffix}
+Release:           0%{?dist}
 Group:             Development/Tools
 License:           MPL
 URL:               http://www.erlang.org
 
-Source0:           http://www.erlang.org/download/otp_src_%{ver_maj}.%{ver_min}.tar.gz
+Source0:           https://github.com/erlang/otp/archive/OTP-%{ver_string}.tar.gz
 Source1:           http://www.erlang.org/download/otp_doc_html_%{ver_maj}.%{ver_min}.tar.gz
 Source2:           http://www.erlang.org/download/otp_doc_man_%{ver_maj}.%{ver_min}.tar.gz
 
@@ -105,7 +109,7 @@ Requires:          %{name}-typer = %{version}
 Requires:          %{name}-xmerl = %{version}
 
 Provides:          %{name} = %{version}-%{release}
-Provides:          %{realname} = %{ver_maj}.%{ver_min}-%{release}
+Provides:          %{realname} = %{ver_string}-%{release}
 
 Conflicts:         erlang erlangR15 erlangR16 erlang18 erlang19
 
@@ -227,8 +231,8 @@ Requires: %{name}-base = %{version}-%{release}
 Group:    Development/Tools
 
 %description -n %{name}-manpages
-Documentation for the Erlang programming language in `man' format. This
-documentation can be read using the command `erl -man mod', where `mod' is
+Documentation for the Erlang programming language in `man` format. This
+documentation can be read using the command `erl -man mod`, where 'mod' is
 the name of the module you want documentation on.
 
 ################################################################################
@@ -781,7 +785,7 @@ a few bugs in the scanner, and improves HTML export.
 ################################################################################
 
 %prep
-%setup -qn otp_src_%{ver_maj}.%{ver_min}
+%setup -qn otp-OTP-%{ver_string}
 
 tar xzvf %{SOURCE10}
 
@@ -799,6 +803,7 @@ export BUILDDIR=$(pwd)
 
 pushd libressl-%{libre_ver}
   mkdir build
+  # perfecto:absolve 2
   ./configure --prefix=$(pwd)/build --enable-shared=no
   %{__make} %{?_smp_mflags}
   %{__make} install
@@ -809,6 +814,8 @@ popd
 export CFLAGS="%{optflags} -fno-strict-aliasing"
 export CXXLAGS=$CFLAGS
 ERL_TOP=`pwd`; export ERL_TOP
+
+./otp_build autoconf
 
 %configure \
   --prefix=%{_prefix} \
@@ -1119,6 +1126,9 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Sat Jul 28 2018 Gleb Goncharov <g.goncharov@fun-box.ru> - 20.3.8.3-0
+- Updated to latest release
+
 * Tue Apr 03 2018 Anton Novojilov <andy@essentialkaos.com> - 20.3-1
 - Using GCC from devtoolset-3 for build
 

--- a/specs/erlangR21.spec
+++ b/specs/erlangR21.spec
@@ -42,6 +42,9 @@
 %define eprefix           %{_prefix}%{_lib32}
 %define ver_maj           21
 %define ver_min           0
+%define ver_patch         4
+%define ver_suffix        0.4
+%define ver_string        21.%{ver_suffix}
 %define realname          erlang
 
 %define libre_ver         2.7.4
@@ -50,13 +53,13 @@
 
 Summary:           General-purpose programming language and runtime environment
 Name:              %{realname}%{ver_maj}
-Version:           %{ver_min}
+Version:           %{ver_suffix}
 Release:           0%{?dist}
 Group:             Development/Tools
 License:           MPL
 URL:               http://www.erlang.org
 
-Source0:           http://www.erlang.org/download/otp_src_%{ver_maj}.%{ver_min}.tar.gz
+Source0:           https://github.com/erlang/otp/archive/OTP-%{ver_string}.tar.gz
 Source1:           http://www.erlang.org/download/otp_doc_html_%{ver_maj}.%{ver_min}.tar.gz
 Source2:           http://www.erlang.org/download/otp_doc_man_%{ver_maj}.%{ver_min}.tar.gz
 
@@ -106,7 +109,7 @@ Requires:          %{name}-typer = %{version}
 Requires:          %{name}-xmerl = %{version}
 
 Provides:          %{name} = %{version}-%{release}
-Provides:          %{realname} = %{ver_maj}.%{ver_min}-%{release}
+Provides:          %{realname} = %{ver_string}-%{release}
 
 Conflicts:         erlang erlangR15 erlangR16 erlang18 erlang19
 
@@ -221,8 +224,8 @@ Requires: %{name}-base = %{version}-%{release}
 Group:    Development/Tools
 
 %description -n %{name}-manpages
-Documentation for the Erlang programming language in `man' format. This
-documentation can be read using the command `erl -man mod', where `mod' is
+Documentation for the Erlang programming language in `man` format. This
+documentation can be read using the command `erl -man mod`, where 'mod' is
 the name of the module you want documentation on.
 
 ################################################################################
@@ -691,7 +694,7 @@ a few bugs in the scanner, and improves HTML export.
 ################################################################################
 
 %prep
-%setup -qn otp_src_%{ver_maj}.%{ver_min}
+%setup -qn otp-OTP-%{ver_string}
 
 tar xzvf %{SOURCE10}
 
@@ -719,6 +722,8 @@ popd
 export CFLAGS="%{optflags} -fno-strict-aliasing"
 export CXXLAGS=$CFLAGS
 ERL_TOP=`pwd`; export ERL_TOP
+
+./otp_build autoconf
 
 %configure \
   --prefix=%{_prefix} \
@@ -1001,5 +1006,8 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Sat Jul 28 2018 Gleb Goncharov <g.goncharov@fun-box.ru> - 21.0.4-0
+- Updated to latest release
+
 * Wed Jun 20 2018 Anton Novojilov <andy@essentialkaos.com> - 21.0-0
 - Initial build


### PR DESCRIPTION
Hi, @andyone.

I found that Erlang OTP releases on official website does not have tarballs with patch versions with a variety of bug fixes. So I suggest you building packages from GitHub directly.