### PR TITLE
Added python-yaml to Provides for PyYAML and PyYAML34 specs

### DIFF
--- a/specs/PyYAML/PyYAML.spec
+++ b/specs/PyYAML/PyYAML.spec
@@ -19,6 +19,7 @@ Requires:        python
 
 Provides:        python-%{name} = %{version}-%{release}
 Provides:        %{name} = %{version}-%{release}
+Provides:        python-yaml = %{version}-%{release}
 
 ################################################################################
 
@@ -62,6 +63,9 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Mon Nov 19 2018 Andrey Kulikov <avk@brewkeeper.net> - 3.13-1
+- Added python-yaml to Provides
+
 * Wed Sep 12 2018 Anton Novojilov <andy@essentialkaos.com> - 3.13-0
 - Updated to latest stable release
 

--- a/specs/PyYAML/PyYAML34.spec
+++ b/specs/PyYAML/PyYAML34.spec
@@ -28,6 +28,7 @@ BuildRequires:   libyaml-devel >= 0.2.1
 Requires:        python34
 
 Provides:        %{name} = %{version}-%{release}
+Provides:        python34-yaml = %{version}-%{release}
 
 ################################################################################
 
@@ -71,6 +72,9 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Mon Nov 19 2018 Andrey Kulikov <avk@brewkeeper.net> - 3.13-1
+- Added python34-yaml to Provides
+
 * Wed Sep 12 2018 Anton Novojilov <andy@essentialkaos.com> - 3.13-0
 - Updated to latest stable release
 


### PR DESCRIPTION
The problem is that EPEL packages require python-yaml or python34-yaml instead of the "real" package names.

```
--> Finished Dependency Resolution
Error: Package: docker-compose-1.18.0-2.el7.noarch (epel)
           Requires: python34-yaml >= 3.10
```