### PR TITLE
Separate ClickHouse client subpackage from server

### DIFF
--- a/specs/clickhouse.spec
+++ b/specs/clickhouse.spec
@@ -306,7 +306,7 @@ fi
 
 %changelog
 * Tue Mar 17 2019 Gleb Goncharov <andy@essentialkaos.com> - 19.17.5.18-1
-- Separate clickhouse-client package from the clickhouse-server
+- Removed dependency of clickhouse-client from clickhouse-server
 
 * Fri Dec 13 2019 Anton Novojilov <andy@essentialkaos.com> - 19.17.5.18-0
 - Updated to the latest stable release

--- a/specs/clickhouse.spec
+++ b/specs/clickhouse.spec
@@ -100,7 +100,7 @@ system that allows generating analytical data reports in real time.
 Summary:           ClickHouse client binary
 Group:             Applications/Databases
 
-Requires:          %{name}-server = %{version}-%{release}
+Requires:          %{name}-common-static = %{version}-%{release}
 
 %description client
 This package contains client binary for ClickHouse DBMS.
@@ -305,6 +305,9 @@ fi
 ################################################################################
 
 %changelog
+* Tue Mar 17 2019 Gleb Goncharov <andy@essentialkaos.com> - 19.17.5.18-1
+- Separate clickhouse-client package from the clickhouse-server
+
 * Fri Dec 13 2019 Anton Novojilov <andy@essentialkaos.com> - 19.17.5.18-0
 - Updated to the latest stable release
 


### PR DESCRIPTION
### What's this PR about

In some cases, sysadmin wants to install `clickhouse-client` package separately from the `clickhouse-server` package. Unfortunately, RPM spec contains direct dependency (in `Requires` tag) `clickhouse-client` from `clickhouse-server`.

This PR provides a quick fix to separate these subpackages.

**Did you try to build the package with this spec?:** No
**Is this ready for review?:** Yes
