### PR TITLE
Update vault and consul to the latest versions

### DIFF
--- a/specs/consul/SOURCES/consul-server.conf
+++ b/specs/consul/SOURCES/consul-server.conf
@@ -8,7 +8,7 @@
   "leave_on_terminate": false,
   "skip_leave_on_interrupt": true,
   "rejoin_after_leave": true,
-  "log_file": "/var/log/consul",
+  "log_file": "/var/log/consul-server/",
   "retry_join": [
     "localhost:8301"
   ]

--- a/specs/consul/consul.spec
+++ b/specs/consul/consul.spec
@@ -53,7 +53,7 @@
 
 Summary:           Tool for service discovery, monitoring and configuration
 Name:              consul
-Version:           1.6.2
+Version:           1.9.2
 Release:           0%{?dist}
 Group:             Applications/Communications
 License:           MPLv2
@@ -154,8 +154,6 @@ mv .src src
 
 %build
 export GOPATH=$(pwd)
-export XC_OS=$(go env GOOS)
-export XC_ARCH=$(go env GOARCH)
 export GO15VENDOREXPERIMENT=1
 export CGO_ENABLED=0
 export GIT_IMPORT="github.com/hashicorp/consul/version"
@@ -163,10 +161,9 @@ export GOLDFLAGS="-X $GIT_IMPORT.GitDescribe=%{version}"
 
 pushd src/github.com/hashicorp/%{name}
   %{__make} %{?_smp_mflags} tools || :
-  $GOPATH/bin/gox -osarch="${XC_OS}/${XC_ARCH}" \
-                  -ldflags "${GOLDFLAGS}" \
-                  -tags="consul" \
-                  -output "$GOPATH/%{name}" .
+  go build -ldflags "${GOLDFLAGS}" \
+           -tags="consul" \
+           -o "$GOPATH/%{name}" main.go
 popd
 
 %install
@@ -310,6 +307,9 @@ fi
 ################################################################################
 
 %changelog
+* Mon Feb 1 2021 Andrey Kulikov <avk@brewkeeper.net> - 1.9.2-0
+- Updated to the latest stable release
+
 * Fri Dec 13 2019 Anton Novojilov <andy@essentialkaos.com> - 1.6.2-0
 - Updated to the latest stable release
 

--- a/specs/vault/vault.spec
+++ b/specs/vault/vault.spec
@@ -57,7 +57,7 @@
 
 Summary:           Tool for managing secrets and protecting sensitive data
 Name:              vault
-Version:           1.3.2
+Version:           1.6.2
 Release:           0%{?dist}
 Group:             Applications/Communications
 License:           MPLv2
@@ -77,7 +77,7 @@ Source100:         checksum.sha512
 
 BuildRoot:         %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
-BuildRequires:     golang >= 1.13
+BuildRequires:     golang >= 1.15.3
 
 Provides:          %{name} = %{version}-%{release}
 
@@ -318,6 +318,9 @@ fi
 ################################################################################
 
 %changelog
+* Mon Feb 1 2021 Andrey Kulikov <avk@brewkeeper.net> - 1.6.2-0
+- Updated to the latest stable release
+
 * Tue Jan 28 2020 Anton Novojilov <andy@essentialkaos.com> - 1.3.2-0
 - Updated to the latest stable release
 


### PR DESCRIPTION
### What's this PR about

* Update `Consul` to 1.9.2
* Update `Vault` to 1.6.2

### Known build problems and traps

Go version at least 1.15.3 is needed to build Vault.

### TODO's:

- [x] Run [`perfecto`](https://github.com/essentialkaos/perfecto) check on your spec file
- [x] Write [`bibop`](https://github.com/essentialkaos/bibop) tests
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**Did you try to build the package with this spec?:** Yes
**Is this ready for review?:** Yes
