### PR TITLE
Improve libverto spec

### DIFF
--- a/specs/libverto.spec
+++ b/specs/libverto.spec
@@ -21,6 +21,7 @@ BuildRoot:       %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildRequires:   make gcc glib2-devel libevent-devel libev-devel chrpath
 
 Obsoletes:       libverto-tevent <= 0.3.1
+Obsoletes:       libverto-tevent-devel <= 0.3.1
 
 Provides:        %{name} = %{version}-%{release}
 

--- a/specs/libverto.spec
+++ b/specs/libverto.spec
@@ -7,7 +7,7 @@
 Summary:         Main loop abstraction library
 Name:            libverto
 Version:         0.3.2
-Release:         0%{?dist}
+Release:         1%{?dist}
 License:         MIT
 Group:           Development/Libraries
 URL:             https://github.com/latchset/libverto
@@ -19,6 +19,8 @@ Source100:       checksum.sha512
 BuildRoot:       %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires:   make gcc glib2-devel libevent-devel libev-devel chrpath
+
+Obsoletes:       libverto-tevent <= 0.3.1
 
 Provides:        %{name} = %{version}-%{release}
 
@@ -231,6 +233,9 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Fri Nov 03 2023 Anton Novojilov <andy@essentialkaos.com> - 0.3.2-1
+- Improved spec
+
 * Thu Sep 22 2022 Anton Novojilov <andy@essentialkaos.com> - 0.3.2-0
 - Fix use-after-free in verto_reinitialize()
 - Fix use-after-free in verto_free()


### PR DESCRIPTION
### What's this PR about

Fixed compatibility with previous versions of the package with the `tevent` subpackage, which was removed in `0.3.2`. 

### Known build problems and traps

—

### TODO's:

- [x] Run [`perfecto`](https://kaos.sh/perfecto) check on your spec file
- [x] Write [`bibop`](https://kaos.sh/bibop) tests
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**Did you try to build the package with this spec?:** Yes
**Is this ready for review?:** Yes
