### PR TITLE
Update Golang to 1.21.4

### DIFF
--- a/specs/golang/golang.spec
+++ b/specs/golang/golang.spec
@@ -31,7 +31,7 @@
 
 Summary:        The Go Programming Language
 Name:           golang
-Version:        1.21.3
+Version:        1.21.4
 Release:        0%{?dist}
 License:        BSD
 Group:          Development/Languages
@@ -237,6 +237,9 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Wed Nov 08 2023 Anton Novojilov <andy@essentialkaos.com> - 1.21.4-0
+- https://github.com/golang/go/issues?q=milestone:Go1.21.4+label:CherryPickApproved
+
 * Wed Oct 11 2023 Anton Novojilov <andy@essentialkaos.com> - 1.21.3-0
 - https://github.com/golang/go/issues?q=milestone:Go1.21.3+label:CherryPickApproved
 


### PR DESCRIPTION
### What's this PR about

Golang updated to the latest stable release — https://github.com/golang/go/issues?q=milestone%3AGo1.21.4

### Known build problems and traps

—

### TODO's:

- [x] Run [`perfecto`](https://kaos.sh/perfecto) check on your spec file
- [x] Write [`bibop`](https://kaos.sh/bibop) tests
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**Did you try to build the package with this spec?:** Yes
**Is this ready for review?:** Yes
