### PR TITLE
PostGIS improvements

### DIFF
--- a/specs/postgresql-10/postgis30.spec
+++ b/specs/postgresql-10/postgis30.spec
@@ -18,6 +18,8 @@
 %define pkgname         %{realname}-%{maj_ver}
 %define fullname        %{realname}30
 
+%define min_geos_ver    3.11
+
 %define __perl_requires   filter-requires-perl-Pg.sh
 
 ################################################################################
@@ -25,7 +27,7 @@
 Summary:         Geographic Information Systems Extensions to PostgreSQL %{pg_ver}
 Name:            %{fullname}_%{pg_ver}
 Version:         3.0.9
-Release:         0%{?dist}
+Release:         1%{?dist}
 License:         GPLv2+
 Group:           Applications/Databases
 URL:             https://www.postgis.net
@@ -39,7 +41,8 @@ BuildRoot:       %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires:   postgresql%{pg_ver}-devel = %{pg_low_fullver}
 BuildRequires:   postgresql%{pg_ver}-libs = %{pg_low_fullver}
-BuildRequires:   gcc-c++ geos-devel >= 3.9 chrpath make pcre-devel hdf5-devel
+BuildRequires:   geos-devel >= %{min_geos_ver}
+BuildRequires:   gcc-c++ chrpath make pcre-devel hdf5-devel
 BuildRequires:   proj-devel libtool flex json-c-devel libxml2-devel
 BuildRequires:   sqlite-devel libgeotiff-devel libpng-devel libtiff-devel
 
@@ -53,8 +56,9 @@ Requires:        gdal-libs >= 3
 %endif
 %endif
 
-Requires:        postgresql%{pg_ver} geos >= 3.9 proj hdf5 json-c pcre
+Requires:        postgresql%{pg_ver} proj hdf5 json-c pcre
 Requires:        %{fullname}_%{pg_ver}-client = %{version}-%{release}
+Requires:        geos >= %{min_geos_ver}
 
 Requires(post):  chkconfig
 
@@ -251,5 +255,8 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Wed Nov 08 2023 Anton Novojilov <andy@essentialkaos.com> - 3.0.9-1
+- Minimal required version of GEOS set to 3.11
+
 * Thu Sep 21 2023 Anton Novojilov <andy@essentialkaos.com> - 3.0.9-0
 - https://git.osgeo.org/gitea/postgis/postgis/raw/tag/3.0.9/NEWS

--- a/specs/postgresql-10/postgis31.spec
+++ b/specs/postgresql-10/postgis31.spec
@@ -18,6 +18,8 @@
 %define pkgname         %{realname}-%{maj_ver}
 %define fullname        %{realname}31
 
+%define min_geos_ver    3.11
+
 %define __perl_requires   filter-requires-perl-Pg.sh
 
 ################################################################################
@@ -25,7 +27,7 @@
 Summary:         Geographic Information Systems Extensions to PostgreSQL %{pg_ver}
 Name:            %{fullname}_%{pg_ver}
 Version:         3.1.9
-Release:         0%{?dist}
+Release:         1%{?dist}
 License:         GPLv2+
 Group:           Applications/Databases
 URL:             https://www.postgis.net
@@ -39,7 +41,8 @@ BuildRoot:       %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires:   postgresql%{pg_ver}-devel = %{pg_low_fullver}
 BuildRequires:   postgresql%{pg_ver}-libs = %{pg_low_fullver}
-BuildRequires:   gcc-c++ geos-devel >= 3.9 chrpath make pcre-devel hdf5-devel
+BuildRequires:   geos-devel >= %{min_geos_ver}
+BuildRequires:   gcc-c++ chrpath make pcre-devel hdf5-devel
 BuildRequires:   proj-devel libtool flex json-c-devel libxml2-devel
 BuildRequires:   sqlite-devel libgeotiff-devel libpng-devel libtiff-devel
 
@@ -53,8 +56,9 @@ Requires:        gdal-libs >= 3
 %endif
 %endif
 
-Requires:        postgresql%{pg_ver} geos >= 3.9 proj hdf5 json-c pcre
+Requires:        postgresql%{pg_ver} proj hdf5 json-c pcre
 Requires:        %{fullname}_%{pg_ver}-client = %{version}-%{release}
+Requires:        geos >= %{min_geos_ver}
 
 Requires(post):  chkconfig
 
@@ -249,5 +253,8 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Wed Nov 08 2023 Anton Novojilov <andy@essentialkaos.com> - 3.1.9-1
+- Minimal required version of GEOS set to 3.11
+
 * Thu Sep 21 2023 Anton Novojilov <andy@essentialkaos.com> - 3.1.9-0
 - https://git.osgeo.org/gitea/postgis/postgis/raw/tag/3.1.9/NEWS

--- a/specs/postgresql-10/postgis32.spec
+++ b/specs/postgresql-10/postgis32.spec
@@ -18,6 +18,8 @@
 %define pkgname         %{realname}-%{maj_ver}
 %define fullname        %{realname}32
 
+%define min_geos_ver    3.11
+
 %define __perl_requires   filter-requires-perl-Pg.sh
 
 ################################################################################
@@ -25,7 +27,7 @@
 Summary:         Geographic Information Systems Extensions to PostgreSQL %{pg_ver}
 Name:            %{fullname}_%{pg_ver}
 Version:         3.2.5
-Release:         0%{?dist}
+Release:         1%{?dist}
 License:         GPLv2+
 Group:           Applications/Databases
 URL:             https://www.postgis.net
@@ -39,7 +41,8 @@ BuildRoot:       %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires:   postgresql%{pg_ver}-devel = %{pg_low_fullver}
 BuildRequires:   postgresql%{pg_ver}-libs = %{pg_low_fullver}
-BuildRequires:   gcc-c++ geos-devel >= 3.9 chrpath make pcre-devel hdf5-devel
+BuildRequires:   geos-devel >= %{min_geos_ver}
+BuildRequires:   gcc-c++ chrpath make pcre-devel hdf5-devel
 BuildRequires:   proj-devel libtool flex json-c-devel libxml2-devel
 BuildRequires:   sqlite-devel libgeotiff-devel libpng-devel libtiff-devel
 
@@ -53,8 +56,9 @@ Requires:        gdal-libs >= 3
 %endif
 %endif
 
-Requires:        postgresql%{pg_ver} geos >= 3.9 proj hdf5 json-c pcre
+Requires:        postgresql%{pg_ver} proj hdf5 json-c pcre
 Requires:        %{fullname}_%{pg_ver}-client = %{version}-%{release}
+Requires:        geos >= %{min_geos_ver}
 
 Requires(post):  chkconfig
 
@@ -249,5 +253,8 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Wed Nov 08 2023 Anton Novojilov <andy@essentialkaos.com> - 3.2.5-1
+- Minimal required version of GEOS set to 3.11
+
 * Thu Sep 21 2023 Anton Novojilov <andy@essentialkaos.com> - 3.2.5-0
 - https://git.osgeo.org/gitea/postgis/postgis/raw/tag/3.2.5/NEWS

--- a/specs/postgresql-11/postgis30.spec
+++ b/specs/postgresql-11/postgis30.spec
@@ -19,6 +19,8 @@
 %define pkgname         %{realname}-%{maj_ver}
 %define fullname        %{realname}30
 
+%define min_geos_ver    3.11
+
 %define __perl_requires   filter-requires-perl-Pg.sh
 
 ################################################################################
@@ -26,7 +28,7 @@
 Summary:         Geographic Information Systems Extensions to PostgreSQL %{pg_ver}
 Name:            %{fullname}_%{pg_ver}
 Version:         3.0.9
-Release:         0%{?dist}
+Release:         1%{?dist}
 License:         GPLv2+
 Group:           Applications/Databases
 URL:             https://www.postgis.net
@@ -40,7 +42,8 @@ BuildRoot:       %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires:   postgresql%{pg_ver}-devel = %{pg_low_fullver}
 BuildRequires:   postgresql%{pg_ver}-libs = %{pg_low_fullver}
-BuildRequires:   gcc-c++ geos-devel >= 3.9 chrpath make pcre-devel hdf5-devel
+BuildRequires:   geos-devel >= %{min_geos_ver}
+BuildRequires:   gcc-c++ chrpath make pcre-devel hdf5-devel
 BuildRequires:   proj-devel libtool flex json-c-devel libxml2-devel
 BuildRequires:   sqlite-devel libgeotiff-devel libpng-devel libtiff-devel
 
@@ -63,8 +66,9 @@ Requires:        gdal-libs >= 3
 %endif
 %endif
 
-Requires:        postgresql%{pg_ver} geos >= 3.9 proj hdf5 json-c pcre
+Requires:        postgresql%{pg_ver} proj hdf5 json-c pcre
 Requires:        %{fullname}_%{pg_ver}-client = %{version}-%{release}
+Requires:        geos >= %{min_geos_ver}
 
 Requires(post):  chkconfig
 
@@ -264,5 +268,8 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Wed Nov 08 2023 Anton Novojilov <andy@essentialkaos.com> - 3.0.9-1
+- Minimal required version of GEOS set to 3.11
+
 * Thu Sep 21 2023 Anton Novojilov <andy@essentialkaos.com> - 3.0.9-0
 - https://git.osgeo.org/gitea/postgis/postgis/raw/tag/3.0.9/NEWS

--- a/specs/postgresql-11/postgis31.spec
+++ b/specs/postgresql-11/postgis31.spec
@@ -19,6 +19,8 @@
 %define pkgname         %{realname}-%{maj_ver}
 %define fullname        %{realname}31
 
+%define min_geos_ver    3.11
+
 %define __perl_requires   filter-requires-perl-Pg.sh
 
 ################################################################################
@@ -26,7 +28,7 @@
 Summary:         Geographic Information Systems Extensions to PostgreSQL %{pg_ver}
 Name:            %{fullname}_%{pg_ver}
 Version:         3.1.9
-Release:         0%{?dist}
+Release:         1%{?dist}
 License:         GPLv2+
 Group:           Applications/Databases
 URL:             https://www.postgis.net
@@ -40,7 +42,8 @@ BuildRoot:       %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires:   postgresql%{pg_ver}-devel = %{pg_low_fullver}
 BuildRequires:   postgresql%{pg_ver}-libs = %{pg_low_fullver}
-BuildRequires:   gcc-c++ geos-devel >= 3.9 chrpath make pcre-devel hdf5-devel
+BuildRequires:   geos-devel >= %{min_geos_ver}
+BuildRequires:   gcc-c++ chrpath make pcre-devel hdf5-devel
 BuildRequires:   proj-devel libtool flex json-c-devel libxml2-devel
 BuildRequires:   sqlite-devel libgeotiff-devel libpng-devel libtiff-devel
 
@@ -63,8 +66,9 @@ Requires:        gdal-libs >= 3
 %endif
 %endif
 
-Requires:        postgresql%{pg_ver} geos >= 3.9 proj hdf5 json-c pcre
+Requires:        postgresql%{pg_ver} proj hdf5 json-c pcre
 Requires:        %{fullname}_%{pg_ver}-client = %{version}-%{release}
+Requires:        geos >= %{min_geos_ver}
 
 Requires(post):  chkconfig
 
@@ -262,5 +266,8 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Wed Nov 08 2023 Anton Novojilov <andy@essentialkaos.com> - 3.1.9-1
+- Minimal required version of GEOS set to 3.11
+
 * Thu Sep 21 2023 Anton Novojilov <andy@essentialkaos.com> - 3.1.9-0
 - https://git.osgeo.org/gitea/postgis/postgis/raw/tag/3.1.9/NEWS

--- a/specs/postgresql-11/postgis32.spec
+++ b/specs/postgresql-11/postgis32.spec
@@ -19,6 +19,8 @@
 %define pkgname         %{realname}-%{maj_ver}
 %define fullname        %{realname}32
 
+%define min_geos_ver    3.11
+
 %define __perl_requires   filter-requires-perl-Pg.sh
 
 ################################################################################
@@ -26,7 +28,7 @@
 Summary:         Geographic Information Systems Extensions to PostgreSQL %{pg_ver}
 Name:            %{fullname}_%{pg_ver}
 Version:         3.2.5
-Release:         0%{?dist}
+Release:         1%{?dist}
 License:         GPLv2+
 Group:           Applications/Databases
 URL:             https://www.postgis.net
@@ -43,7 +45,8 @@ BuildRequires:   postgresql%{pg_ver}-libs = %{pg_low_fullver}
 
 BuildRequires:   postgresql%{pg_ver}-devel = %{pg_low_fullver}
 BuildRequires:   postgresql%{pg_ver}-libs = %{pg_low_fullver}
-BuildRequires:   gcc-c++ geos-devel >= 3.9 chrpath make pcre-devel hdf5-devel
+BuildRequires:   geos-devel >= %{min_geos_ver}
+BuildRequires:   gcc-c++ chrpath make pcre-devel hdf5-devel
 BuildRequires:   proj-devel libtool flex json-c-devel libxml2-devel
 BuildRequires:   sqlite-devel libgeotiff-devel libpng-devel libtiff-devel
 
@@ -66,8 +69,9 @@ Requires:        gdal-libs >= 3
 %endif
 %endif
 
-Requires:        postgresql%{pg_ver} geos >= 3.9 proj hdf5 json-c pcre
+Requires:        postgresql%{pg_ver} proj hdf5 json-c pcre
 Requires:        %{fullname}_%{pg_ver}-client = %{version}-%{release}
+Requires:        geos >= %{min_geos_ver}
 
 Requires(post):  chkconfig
 
@@ -265,5 +269,8 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Wed Nov 08 2023 Anton Novojilov <andy@essentialkaos.com> - 3.2.5-1
+- Minimal required version of GEOS set to 3.11
+
 * Thu Sep 21 2023 Anton Novojilov <andy@essentialkaos.com> - 3.2.5-0
 - https://git.osgeo.org/gitea/postgis/postgis/raw/tag/3.2.5/NEWS

--- a/specs/postgresql-11/postgis33.spec
+++ b/specs/postgresql-11/postgis33.spec
@@ -19,6 +19,8 @@
 %define pkgname         %{realname}-%{maj_ver}
 %define fullname        %{realname}33
 
+%define min_geos_ver    3.11
+
 %define __perl_requires   filter-requires-perl-Pg.sh
 
 ################################################################################
@@ -26,7 +28,7 @@
 Summary:         Geographic Information Systems Extensions to PostgreSQL %{pg_ver}
 Name:            %{fullname}_%{pg_ver}
 Version:         3.3.4
-Release:         0%{?dist}
+Release:         1%{?dist}
 License:         GPLv2+
 Group:           Applications/Databases
 URL:             https://www.postgis.net
@@ -40,7 +42,8 @@ BuildRoot:       %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires:   postgresql%{pg_ver}-devel = %{pg_low_fullver}
 BuildRequires:   postgresql%{pg_ver}-libs = %{pg_low_fullver}
-BuildRequires:   gcc-c++ geos-devel >= 3.9 chrpath make pcre-devel hdf5-devel
+BuildRequires:   geos-devel >= %{min_geos_ver}
+BuildRequires:   gcc-c++ chrpath make pcre-devel hdf5-devel
 BuildRequires:   proj-devel libtool flex json-c-devel libxml2-devel
 BuildRequires:   sqlite-devel libgeotiff-devel libpng-devel libtiff-devel
 
@@ -63,8 +66,9 @@ Requires:        gdal-libs >= 3
 %endif
 %endif
 
-Requires:        postgresql%{pg_ver} geos >= 3.9 proj hdf5 json-c pcre
+Requires:        postgresql%{pg_ver} proj hdf5 json-c pcre
 Requires:        %{fullname}_%{pg_ver}-client = %{version}-%{release}
+Requires:        geos >= %{min_geos_ver}
 
 Requires(post):  chkconfig
 
@@ -271,5 +275,8 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Wed Nov 08 2023 Anton Novojilov <andy@essentialkaos.com> - 3.3.4-1
+- Minimal required version of GEOS set to 3.11
+
 * Thu Sep 21 2023 Anton Novojilov <andy@essentialkaos.com> - 3.3.4-0
 - https://git.osgeo.org/gitea/postgis/postgis/raw/tag/3.3.4/NEWS

--- a/specs/postgresql-12/postgis30.spec
+++ b/specs/postgresql-12/postgis30.spec
@@ -19,6 +19,8 @@
 %define pkgname         %{realname}-%{maj_ver}
 %define fullname        %{realname}30
 
+%define min_geos_ver    3.11
+
 %define __perl_requires   filter-requires-perl-Pg.sh
 
 ################################################################################
@@ -26,7 +28,7 @@
 Summary:         Geographic Information Systems Extensions to PostgreSQL %{pg_ver}
 Name:            %{fullname}_%{pg_ver}
 Version:         3.0.9
-Release:         0%{?dist}
+Release:         1%{?dist}
 License:         GPLv2+
 Group:           Applications/Databases
 URL:             https://www.postgis.net
@@ -40,7 +42,8 @@ BuildRoot:       %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires:   postgresql%{pg_ver}-devel = %{pg_low_fullver}
 BuildRequires:   postgresql%{pg_ver}-libs = %{pg_low_fullver}
-BuildRequires:   gcc-c++ geos-devel >= 3.9 chrpath make pcre-devel hdf5-devel
+BuildRequires:   geos-devel >= %{min_geos_ver}
+BuildRequires:   gcc-c++ chrpath make pcre-devel hdf5-devel
 BuildRequires:   proj-devel libtool flex json-c-devel libxml2-devel
 BuildRequires:   sqlite-devel libgeotiff-devel libpng-devel libtiff-devel
 
@@ -63,8 +66,9 @@ Requires:        gdal-libs >= 3
 %endif
 %endif
 
-Requires:        postgresql%{pg_ver} geos >= 3.9 proj hdf5 json-c pcre
+Requires:        postgresql%{pg_ver} proj hdf5 json-c pcre
 Requires:        %{fullname}_%{pg_ver}-client = %{version}-%{release}
+Requires:        geos >= %{min_geos_ver}
 
 Requires(post):  chkconfig
 
@@ -264,5 +268,8 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Wed Nov 08 2023 Anton Novojilov <andy@essentialkaos.com> - 3.0.9-1
+- Minimal required version of GEOS set to 3.11
+
 * Thu Sep 21 2023 Anton Novojilov <andy@essentialkaos.com> - 3.0.9-0
 - https://git.osgeo.org/gitea/postgis/postgis/raw/tag/3.0.9/NEWS

--- a/specs/postgresql-12/postgis31.spec
+++ b/specs/postgresql-12/postgis31.spec
@@ -19,6 +19,8 @@
 %define pkgname         %{realname}-%{maj_ver}
 %define fullname        %{realname}31
 
+%define min_geos_ver    3.11
+
 %define __perl_requires   filter-requires-perl-Pg.sh
 
 ################################################################################
@@ -26,7 +28,7 @@
 Summary:         Geographic Information Systems Extensions to PostgreSQL %{pg_ver}
 Name:            %{fullname}_%{pg_ver}
 Version:         3.1.9
-Release:         0%{?dist}
+Release:         1%{?dist}
 License:         GPLv2+
 Group:           Applications/Databases
 URL:             https://www.postgis.net
@@ -40,7 +42,8 @@ BuildRoot:       %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires:   postgresql%{pg_ver}-devel = %{pg_low_fullver}
 BuildRequires:   postgresql%{pg_ver}-libs = %{pg_low_fullver}
-BuildRequires:   gcc-c++ geos-devel >= 3.9 chrpath make pcre-devel hdf5-devel
+BuildRequires:   geos-devel >= %{min_geos_ver}
+BuildRequires:   gcc-c++ chrpath make pcre-devel hdf5-devel
 BuildRequires:   proj-devel libtool flex json-c-devel libxml2-devel
 BuildRequires:   sqlite-devel libgeotiff-devel libpng-devel libtiff-devel
 
@@ -63,8 +66,9 @@ Requires:        gdal-libs >= 3
 %endif
 %endif
 
-Requires:        postgresql%{pg_ver} geos >= 3.9 proj hdf5 json-c pcre
+Requires:        postgresql%{pg_ver} proj hdf5 json-c pcre
 Requires:        %{fullname}_%{pg_ver}-client = %{version}-%{release}
+Requires:        geos >= %{min_geos_ver}
 
 Requires(post):  chkconfig
 
@@ -262,5 +266,8 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Wed Nov 08 2023 Anton Novojilov <andy@essentialkaos.com> - 3.1.9-1
+- Minimal required version of GEOS set to 3.11
+
 * Thu Sep 21 2023 Anton Novojilov <andy@essentialkaos.com> - 3.1.9-0
 - https://git.osgeo.org/gitea/postgis/postgis/raw/tag/3.1.9/NEWS

--- a/specs/postgresql-12/postgis32.spec
+++ b/specs/postgresql-12/postgis32.spec
@@ -19,6 +19,8 @@
 %define pkgname         %{realname}-%{maj_ver}
 %define fullname        %{realname}32
 
+%define min_geos_ver    3.11
+
 %define __perl_requires   filter-requires-perl-Pg.sh
 
 ################################################################################
@@ -26,7 +28,7 @@
 Summary:         Geographic Information Systems Extensions to PostgreSQL %{pg_ver}
 Name:            %{fullname}_%{pg_ver}
 Version:         3.2.5
-Release:         0%{?dist}
+Release:         1%{?dist}
 License:         GPLv2+
 Group:           Applications/Databases
 URL:             https://www.postgis.net
@@ -40,7 +42,8 @@ BuildRoot:       %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires:   postgresql%{pg_ver}-devel = %{pg_low_fullver}
 BuildRequires:   postgresql%{pg_ver}-libs = %{pg_low_fullver}
-BuildRequires:   gcc-c++ geos-devel >= 3.9 chrpath make pcre-devel hdf5-devel
+BuildRequires:   geos-devel >= %{min_geos_ver}
+BuildRequires:   gcc-c++ chrpath make pcre-devel hdf5-devel
 BuildRequires:   proj-devel libtool flex json-c-devel libxml2-devel
 BuildRequires:   sqlite-devel libgeotiff-devel libpng-devel libtiff-devel
 
@@ -63,8 +66,9 @@ Requires:        gdal-libs >= 3
 %endif
 %endif
 
-Requires:        postgresql%{pg_ver} geos >= 3.9 proj hdf5 json-c pcre
+Requires:        postgresql%{pg_ver} proj hdf5 json-c pcre
 Requires:        %{fullname}_%{pg_ver}-client = %{version}-%{release}
+Requires:        geos >= %{min_geos_ver}
 
 Requires(post):  chkconfig
 
@@ -262,5 +266,8 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Wed Nov 08 2023 Anton Novojilov <andy@essentialkaos.com> - 3.2.5-1
+- Minimal required version of GEOS set to 3.11
+
 * Thu Sep 21 2023 Anton Novojilov <andy@essentialkaos.com> - 3.2.5-0
 - https://git.osgeo.org/gitea/postgis/postgis/raw/tag/3.2.5/NEWS

--- a/specs/postgresql-12/postgis33.spec
+++ b/specs/postgresql-12/postgis33.spec
@@ -19,6 +19,8 @@
 %define pkgname         %{realname}-%{maj_ver}
 %define fullname        %{realname}33
 
+%define min_geos_ver    3.11
+
 %define __perl_requires   filter-requires-perl-Pg.sh
 
 ################################################################################
@@ -26,7 +28,7 @@
 Summary:         Geographic Information Systems Extensions to PostgreSQL %{pg_ver}
 Name:            %{fullname}_%{pg_ver}
 Version:         3.3.4
-Release:         0%{?dist}
+Release:         1%{?dist}
 License:         GPLv2+
 Group:           Applications/Databases
 URL:             https://www.postgis.net
@@ -40,7 +42,8 @@ BuildRoot:       %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires:   postgresql%{pg_ver}-devel = %{pg_low_fullver}
 BuildRequires:   postgresql%{pg_ver}-libs = %{pg_low_fullver}
-BuildRequires:   gcc-c++ geos-devel >= 3.9 chrpath make pcre-devel hdf5-devel
+BuildRequires:   geos-devel >= %{min_geos_ver}
+BuildRequires:   gcc-c++ chrpath make pcre-devel hdf5-devel
 BuildRequires:   proj-devel libtool flex json-c-devel libxml2-devel
 BuildRequires:   sqlite-devel libgeotiff-devel libpng-devel libtiff-devel
 
@@ -63,8 +66,9 @@ Requires:        gdal-libs >= 3
 %endif
 %endif
 
-Requires:        postgresql%{pg_ver} geos >= 3.9 proj hdf5 json-c pcre
+Requires:        postgresql%{pg_ver} proj hdf5 json-c pcre
 Requires:        %{fullname}_%{pg_ver}-client = %{version}-%{release}
+Requires:        geos >= %{min_geos_ver}
 
 Requires(post):  chkconfig
 
@@ -271,5 +275,8 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Wed Nov 08 2023 Anton Novojilov <andy@essentialkaos.com> - 3.3.4-1
+- Minimal required version of GEOS set to 3.11
+
 * Thu Sep 21 2023 Anton Novojilov <andy@essentialkaos.com> - 3.3.4-0
 - https://git.osgeo.org/gitea/postgis/postgis/raw/tag/3.3.4/NEWS

--- a/specs/postgresql-12/postgis34.spec
+++ b/specs/postgresql-12/postgis34.spec
@@ -19,6 +19,8 @@
 %define pkgname         %{realname}-%{maj_ver}
 %define fullname        %{realname}34
 
+%define min_geos_ver    3.11
+
 %define __perl_requires   filter-requires-perl-Pg.sh
 
 ################################################################################
@@ -26,7 +28,7 @@
 Summary:         Geographic Information Systems Extensions to PostgreSQL %{pg_ver}
 Name:            %{fullname}_%{pg_ver}
 Version:         3.4.0
-Release:         0%{?dist}
+Release:         1%{?dist}
 License:         GPLv2+
 Group:           Applications/Databases
 URL:             https://www.postgis.net
@@ -40,7 +42,8 @@ BuildRoot:       %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires:   postgresql%{pg_ver}-devel = %{pg_low_fullver}
 BuildRequires:   postgresql%{pg_ver}-libs = %{pg_low_fullver}
-BuildRequires:   gcc-c++ geos-devel >= 3.9 chrpath make pcre-devel hdf5-devel
+BuildRequires:   geos-devel >= %{min_geos_ver}
+BuildRequires:   gcc-c++ chrpath make pcre-devel hdf5-devel
 BuildRequires:   proj-devel libtool flex json-c-devel libxml2-devel
 BuildRequires:   sqlite-devel libgeotiff-devel libpng-devel libtiff-devel
 
@@ -63,8 +66,9 @@ Requires:        gdal-libs >= 3
 %endif
 %endif
 
-Requires:        postgresql%{pg_ver} geos >= 3.9 proj hdf5 json-c pcre
+Requires:        postgresql%{pg_ver} proj hdf5 json-c pcre
 Requires:        %{fullname}_%{pg_ver}-client = %{version}-%{release}
+Requires:        geos >= %{min_geos_ver}
 
 Requires(post):  chkconfig
 
@@ -274,5 +278,8 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Wed Nov 08 2023 Anton Novojilov <andy@essentialkaos.com> - 3.4.0-1
+- Minimal required version of GEOS set to 3.11
+
 * Thu Sep 21 2023 Anton Novojilov <andy@essentialkaos.com> - 3.4.0-0
 - https://git.osgeo.org/gitea/postgis/postgis/raw/tag/3.4.0/NEWS

--- a/specs/postgresql-13/postgis31.spec
+++ b/specs/postgresql-13/postgis31.spec
@@ -19,6 +19,8 @@
 %define pkgname         %{realname}-%{maj_ver}
 %define fullname        %{realname}31
 
+%define min_geos_ver    3.11
+
 %define __perl_requires   filter-requires-perl-Pg.sh
 
 ################################################################################
@@ -26,7 +28,7 @@
 Summary:         Geographic Information Systems Extensions to PostgreSQL %{pg_ver}
 Name:            %{fullname}_%{pg_ver}
 Version:         3.1.9
-Release:         0%{?dist}
+Release:         1%{?dist}
 License:         GPLv2+
 Group:           Applications/Databases
 URL:             https://www.postgis.net
@@ -40,7 +42,8 @@ BuildRoot:       %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires:   postgresql%{pg_ver}-devel = %{pg_low_fullver}
 BuildRequires:   postgresql%{pg_ver}-libs = %{pg_low_fullver}
-BuildRequires:   gcc-c++ geos-devel >= 3.9 chrpath make pcre-devel hdf5-devel
+BuildRequires:   geos-devel >= %{min_geos_ver}
+BuildRequires:   gcc-c++ chrpath make pcre-devel hdf5-devel
 BuildRequires:   proj-devel libtool flex json-c-devel libxml2-devel
 BuildRequires:   sqlite-devel libgeotiff-devel libpng-devel libtiff-devel
 
@@ -63,8 +66,9 @@ Requires:        gdal-libs >= 3
 %endif
 %endif
 
-Requires:        postgresql%{pg_ver} geos >= 3.9 proj hdf5 json-c pcre
+Requires:        postgresql%{pg_ver} proj hdf5 json-c pcre
 Requires:        %{fullname}_%{pg_ver}-client = %{version}-%{release}
+Requires:        geos >= %{min_geos_ver}
 
 Requires(post):  chkconfig
 
@@ -262,5 +266,8 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Wed Nov 08 2023 Anton Novojilov <andy@essentialkaos.com> - 3.1.9-1
+- Minimal required version of GEOS set to 3.11
+
 * Thu Sep 21 2023 Anton Novojilov <andy@essentialkaos.com> - 3.1.9-0
 - https://git.osgeo.org/gitea/postgis/postgis/raw/tag/3.1.9/NEWS

--- a/specs/postgresql-13/postgis32.spec
+++ b/specs/postgresql-13/postgis32.spec
@@ -19,6 +19,8 @@
 %define pkgname         %{realname}-%{maj_ver}
 %define fullname        %{realname}32
 
+%define min_geos_ver    3.11
+
 %define __perl_requires   filter-requires-perl-Pg.sh
 
 ################################################################################
@@ -26,7 +28,7 @@
 Summary:         Geographic Information Systems Extensions to PostgreSQL %{pg_ver}
 Name:            %{fullname}_%{pg_ver}
 Version:         3.2.5
-Release:         0%{?dist}
+Release:         1%{?dist}
 License:         GPLv2+
 Group:           Applications/Databases
 URL:             https://www.postgis.net
@@ -40,7 +42,8 @@ BuildRoot:       %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires:   postgresql%{pg_ver}-devel = %{pg_low_fullver}
 BuildRequires:   postgresql%{pg_ver}-libs = %{pg_low_fullver}
-BuildRequires:   gcc-c++ geos-devel >= 3.9 chrpath make pcre-devel hdf5-devel
+BuildRequires:   geos-devel >= %{min_geos_ver}
+BuildRequires:   gcc-c++ chrpath make pcre-devel hdf5-devel
 BuildRequires:   proj-devel libtool flex json-c-devel libxml2-devel
 BuildRequires:   sqlite-devel libgeotiff-devel libpng-devel libtiff-devel
 
@@ -63,8 +66,9 @@ Requires:        gdal-libs >= 3
 %endif
 %endif
 
-Requires:        postgresql%{pg_ver} geos >= 3.9 proj hdf5 json-c pcre
+Requires:        postgresql%{pg_ver} proj hdf5 json-c pcre
 Requires:        %{fullname}_%{pg_ver}-client = %{version}-%{release}
+Requires:        geos >= %{min_geos_ver}
 
 Requires(post):  chkconfig
 
@@ -262,5 +266,8 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Wed Nov 08 2023 Anton Novojilov <andy@essentialkaos.com> - 3.2.5-1
+- Minimal required version of GEOS set to 3.11
+
 * Thu Sep 21 2023 Anton Novojilov <andy@essentialkaos.com> - 3.2.5-0
 - https://git.osgeo.org/gitea/postgis/postgis/raw/tag/3.2.5/NEWS

--- a/specs/postgresql-13/postgis33.spec
+++ b/specs/postgresql-13/postgis33.spec
@@ -19,6 +19,8 @@
 %define pkgname         %{realname}-%{maj_ver}
 %define fullname        %{realname}33
 
+%define min_geos_ver    3.11
+
 %define __perl_requires   filter-requires-perl-Pg.sh
 
 ################################################################################
@@ -26,7 +28,7 @@
 Summary:         Geographic Information Systems Extensions to PostgreSQL %{pg_ver}
 Name:            %{fullname}_%{pg_ver}
 Version:         3.3.4
-Release:         0%{?dist}
+Release:         1%{?dist}
 License:         GPLv2+
 Group:           Applications/Databases
 URL:             https://www.postgis.net
@@ -40,7 +42,8 @@ BuildRoot:       %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires:   postgresql%{pg_ver}-devel = %{pg_low_fullver}
 BuildRequires:   postgresql%{pg_ver}-libs = %{pg_low_fullver}
-BuildRequires:   gcc-c++ geos-devel >= 3.9 chrpath make pcre-devel hdf5-devel
+BuildRequires:   geos-devel >= %{min_geos_ver}
+BuildRequires:   gcc-c++ chrpath make pcre-devel hdf5-devel
 BuildRequires:   proj-devel libtool flex json-c-devel libxml2-devel
 BuildRequires:   sqlite-devel libgeotiff-devel libpng-devel libtiff-devel
 
@@ -63,8 +66,9 @@ Requires:        gdal-libs >= 3
 %endif
 %endif
 
-Requires:        postgresql%{pg_ver} geos >= 3.9 proj hdf5 json-c pcre
+Requires:        postgresql%{pg_ver} proj hdf5 json-c pcre
 Requires:        %{fullname}_%{pg_ver}-client = %{version}-%{release}
+Requires:        geos >= %{min_geos_ver}
 
 Requires(post):  chkconfig
 
@@ -271,5 +275,8 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Wed Nov 08 2023 Anton Novojilov <andy@essentialkaos.com> - 3.3.4-1
+- Minimal required version of GEOS set to 3.11
+
 * Thu Sep 21 2023 Anton Novojilov <andy@essentialkaos.com> - 3.3.4-0
 - https://git.osgeo.org/gitea/postgis/postgis/raw/tag/3.3.4/NEWS

--- a/specs/postgresql-13/postgis34.spec
+++ b/specs/postgresql-13/postgis34.spec
@@ -19,6 +19,8 @@
 %define pkgname         %{realname}-%{maj_ver}
 %define fullname        %{realname}34
 
+%define min_geos_ver    3.11
+
 %define __perl_requires   filter-requires-perl-Pg.sh
 
 ################################################################################
@@ -26,7 +28,7 @@
 Summary:         Geographic Information Systems Extensions to PostgreSQL %{pg_ver}
 Name:            %{fullname}_%{pg_ver}
 Version:         3.4.0
-Release:         0%{?dist}
+Release:         1%{?dist}
 License:         GPLv2+
 Group:           Applications/Databases
 URL:             https://www.postgis.net
@@ -40,7 +42,8 @@ BuildRoot:       %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires:   postgresql%{pg_ver}-devel = %{pg_low_fullver}
 BuildRequires:   postgresql%{pg_ver}-libs = %{pg_low_fullver}
-BuildRequires:   gcc-c++ geos-devel >= 3.9 chrpath make pcre-devel hdf5-devel
+BuildRequires:   geos-devel >= %{min_geos_ver}
+BuildRequires:   gcc-c++ chrpath make pcre-devel hdf5-devel
 BuildRequires:   proj-devel libtool flex json-c-devel libxml2-devel
 BuildRequires:   sqlite-devel libgeotiff-devel libpng-devel libtiff-devel
 
@@ -63,8 +66,9 @@ Requires:        gdal-libs >= 3
 %endif
 %endif
 
-Requires:        postgresql%{pg_ver} geos >= 3.9 proj hdf5 json-c pcre
+Requires:        postgresql%{pg_ver} proj hdf5 json-c pcre
 Requires:        %{fullname}_%{pg_ver}-client = %{version}-%{release}
+Requires:        geos >= %{min_geos_ver}
 
 Requires(post):  chkconfig
 
@@ -274,5 +278,8 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Wed Nov 08 2023 Anton Novojilov <andy@essentialkaos.com> - 3.4.0-1
+- Minimal required version of GEOS set to 3.11
+
 * Thu Sep 21 2023 Anton Novojilov <andy@essentialkaos.com> - 3.4.0-0
 - https://git.osgeo.org/gitea/postgis/postgis/raw/tag/3.4.0/NEWS

--- a/specs/postgresql-14/postgis31.spec
+++ b/specs/postgresql-14/postgis31.spec
@@ -19,6 +19,8 @@
 %define pkgname         %{realname}-%{maj_ver}
 %define fullname        %{realname}31
 
+%define min_geos_ver    3.11
+
 %define __perl_requires   filter-requires-perl-Pg.sh
 
 ################################################################################
@@ -26,7 +28,7 @@
 Summary:         Geographic Information Systems Extensions to PostgreSQL %{pg_ver}
 Name:            %{fullname}_%{pg_ver}
 Version:         3.1.9
-Release:         0%{?dist}
+Release:         1%{?dist}
 License:         GPLv2+
 Group:           Applications/Databases
 URL:             https://www.postgis.net
@@ -40,7 +42,8 @@ BuildRoot:       %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires:   postgresql%{pg_ver}-devel = %{pg_low_fullver}
 BuildRequires:   postgresql%{pg_ver}-libs = %{pg_low_fullver}
-BuildRequires:   gcc-c++ geos-devel >= 3.9 chrpath make pcre-devel hdf5-devel
+BuildRequires:   geos-devel >= %{min_geos_ver}
+BuildRequires:   gcc-c++ chrpath make pcre-devel hdf5-devel
 BuildRequires:   proj-devel libtool flex json-c-devel libxml2-devel
 BuildRequires:   sqlite-devel libgeotiff-devel libpng-devel libtiff-devel
 
@@ -63,8 +66,9 @@ Requires:        gdal-libs >= 3
 %endif
 %endif
 
-Requires:        postgresql%{pg_ver} geos >= 3.9 proj hdf5 json-c pcre
+Requires:        postgresql%{pg_ver} proj hdf5 json-c pcre
 Requires:        %{fullname}_%{pg_ver}-client = %{version}-%{release}
+Requires:        geos >= %{min_geos_ver}
 
 Requires(post):  chkconfig
 
@@ -262,5 +266,8 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Wed Nov 08 2023 Anton Novojilov <andy@essentialkaos.com> - 3.1.9-1
+- Minimal required version of GEOS set to 3.11
+
 * Thu Sep 21 2023 Anton Novojilov <andy@essentialkaos.com> - 3.1.9-0
 - https://git.osgeo.org/gitea/postgis/postgis/raw/tag/3.1.9/NEWS

--- a/specs/postgresql-14/postgis32.spec
+++ b/specs/postgresql-14/postgis32.spec
@@ -19,6 +19,8 @@
 %define pkgname         %{realname}-%{maj_ver}
 %define fullname        %{realname}32
 
+%define min_geos_ver    3.11
+
 %define __perl_requires   filter-requires-perl-Pg.sh
 
 ################################################################################
@@ -26,7 +28,7 @@
 Summary:         Geographic Information Systems Extensions to PostgreSQL %{pg_ver}
 Name:            %{fullname}_%{pg_ver}
 Version:         3.2.5
-Release:         0%{?dist}
+Release:         1%{?dist}
 License:         GPLv2+
 Group:           Applications/Databases
 URL:             https://www.postgis.net
@@ -40,7 +42,8 @@ BuildRoot:       %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires:   postgresql%{pg_ver}-devel = %{pg_low_fullver}
 BuildRequires:   postgresql%{pg_ver}-libs = %{pg_low_fullver}
-BuildRequires:   gcc-c++ geos-devel >= 3.9 chrpath make pcre-devel hdf5-devel
+BuildRequires:   geos-devel >= %{min_geos_ver}
+BuildRequires:   gcc-c++ chrpath make pcre-devel hdf5-devel
 BuildRequires:   proj-devel libtool flex json-c-devel libxml2-devel
 BuildRequires:   sqlite-devel libgeotiff-devel libpng-devel libtiff-devel
 
@@ -63,8 +66,9 @@ Requires:        gdal-libs >= 3
 %endif
 %endif
 
-Requires:        postgresql%{pg_ver} geos >= 3.9 proj hdf5 json-c pcre
+Requires:        postgresql%{pg_ver} proj hdf5 json-c pcre
 Requires:        %{fullname}_%{pg_ver}-client = %{version}-%{release}
+Requires:        geos >= %{min_geos_ver}
 
 Requires(post):  chkconfig
 
@@ -262,5 +266,8 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Wed Nov 08 2023 Anton Novojilov <andy@essentialkaos.com> - 3.2.5-1
+- Minimal required version of GEOS set to 3.11
+
 * Thu Sep 21 2023 Anton Novojilov <andy@essentialkaos.com> - 3.2.5-0
 - https://git.osgeo.org/gitea/postgis/postgis/raw/tag/3.2.5/NEWS

--- a/specs/postgresql-14/postgis33.spec
+++ b/specs/postgresql-14/postgis33.spec
@@ -19,6 +19,8 @@
 %define pkgname         %{realname}-%{maj_ver}
 %define fullname        %{realname}33
 
+%define min_geos_ver    3.11
+
 %define __perl_requires   filter-requires-perl-Pg.sh
 
 ################################################################################
@@ -26,7 +28,7 @@
 Summary:         Geographic Information Systems Extensions to PostgreSQL %{pg_ver}
 Name:            %{fullname}_%{pg_ver}
 Version:         3.3.4
-Release:         0%{?dist}
+Release:         1%{?dist}
 License:         GPLv2+
 Group:           Applications/Databases
 URL:             https://www.postgis.net
@@ -40,7 +42,8 @@ BuildRoot:       %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires:   postgresql%{pg_ver}-devel = %{pg_low_fullver}
 BuildRequires:   postgresql%{pg_ver}-libs = %{pg_low_fullver}
-BuildRequires:   gcc-c++ geos-devel >= 3.9 chrpath make pcre-devel hdf5-devel
+BuildRequires:   geos-devel >= %{min_geos_ver}
+BuildRequires:   gcc-c++ chrpath make pcre-devel hdf5-devel
 BuildRequires:   proj-devel libtool flex json-c-devel libxml2-devel
 BuildRequires:   sqlite-devel libgeotiff-devel libpng-devel libtiff-devel
 
@@ -63,8 +66,9 @@ Requires:        gdal-libs >= 3
 %endif
 %endif
 
-Requires:        postgresql%{pg_ver} geos >= 3.9 proj hdf5 json-c pcre
+Requires:        postgresql%{pg_ver} proj hdf5 json-c pcre
 Requires:        %{fullname}_%{pg_ver}-client = %{version}-%{release}
+Requires:        geos >= %{min_geos_ver}
 
 Requires(post):  chkconfig
 
@@ -271,5 +275,8 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Wed Nov 08 2023 Anton Novojilov <andy@essentialkaos.com> - 3.3.4-1
+- Minimal required version of GEOS set to 3.11
+
 * Thu Sep 21 2023 Anton Novojilov <andy@essentialkaos.com> - 3.3.4-0
 - https://git.osgeo.org/gitea/postgis/postgis/raw/tag/3.3.4/NEWS

--- a/specs/postgresql-14/postgis34.spec
+++ b/specs/postgresql-14/postgis34.spec
@@ -19,6 +19,8 @@
 %define pkgname         %{realname}-%{maj_ver}
 %define fullname        %{realname}34
 
+%define min_geos_ver    3.11
+
 %define __perl_requires   filter-requires-perl-Pg.sh
 
 ################################################################################
@@ -26,7 +28,7 @@
 Summary:         Geographic Information Systems Extensions to PostgreSQL %{pg_ver}
 Name:            %{fullname}_%{pg_ver}
 Version:         3.4.0
-Release:         0%{?dist}
+Release:         1%{?dist}
 License:         GPLv2+
 Group:           Applications/Databases
 URL:             https://www.postgis.net
@@ -40,7 +42,8 @@ BuildRoot:       %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires:   postgresql%{pg_ver}-devel = %{pg_low_fullver}
 BuildRequires:   postgresql%{pg_ver}-libs = %{pg_low_fullver}
-BuildRequires:   gcc-c++ geos-devel >= 3.9 chrpath make pcre-devel hdf5-devel
+BuildRequires:   geos-devel >= %{min_geos_ver}
+BuildRequires:   gcc-c++ chrpath make pcre-devel hdf5-devel
 BuildRequires:   proj-devel libtool flex json-c-devel libxml2-devel
 BuildRequires:   sqlite-devel libgeotiff-devel libpng-devel libtiff-devel
 
@@ -63,8 +66,9 @@ Requires:        gdal-libs >= 3
 %endif
 %endif
 
-Requires:        postgresql%{pg_ver} geos >= 3.9 proj hdf5 json-c pcre
+Requires:        postgresql%{pg_ver} proj hdf5 json-c pcre
 Requires:        %{fullname}_%{pg_ver}-client = %{version}-%{release}
+Requires:        geos >= %{min_geos_ver}
 
 Requires(post):  chkconfig
 
@@ -274,5 +278,8 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Wed Nov 08 2023 Anton Novojilov <andy@essentialkaos.com> - 3.4.0-1
+- Minimal required version of GEOS set to 3.11
+
 * Thu Sep 21 2023 Anton Novojilov <andy@essentialkaos.com> - 3.4.0-0
 - https://git.osgeo.org/gitea/postgis/postgis/raw/tag/3.4.0/NEWS

--- a/specs/postgresql-15/postgis31.spec
+++ b/specs/postgresql-15/postgis31.spec
@@ -19,6 +19,8 @@
 %define pkgname         %{realname}-%{maj_ver}
 %define fullname        %{realname}31
 
+%define min_geos_ver    3.11
+
 %define __perl_requires   filter-requires-perl-Pg.sh
 
 ################################################################################
@@ -26,7 +28,7 @@
 Summary:         Geographic Information Systems Extensions to PostgreSQL %{pg_ver}
 Name:            %{fullname}_%{pg_ver}
 Version:         3.1.9
-Release:         0%{?dist}
+Release:         1%{?dist}
 License:         GPLv2+
 Group:           Applications/Databases
 URL:             https://www.postgis.net
@@ -40,7 +42,8 @@ BuildRoot:       %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires:   postgresql%{pg_ver}-devel = %{pg_low_fullver}
 BuildRequires:   postgresql%{pg_ver}-libs = %{pg_low_fullver}
-BuildRequires:   gcc-c++ geos-devel >= 3.9 chrpath make pcre-devel hdf5-devel
+BuildRequires:   geos-devel >= %{min_geos_ver}
+BuildRequires:   gcc-c++ chrpath make pcre-devel hdf5-devel
 BuildRequires:   proj-devel libtool flex json-c-devel libxml2-devel
 BuildRequires:   sqlite-devel libgeotiff-devel libpng-devel libtiff-devel
 
@@ -63,8 +66,9 @@ Requires:        gdal-libs >= 3
 %endif
 %endif
 
-Requires:        postgresql%{pg_ver} geos >= 3.9 proj hdf5 json-c pcre
+Requires:        postgresql%{pg_ver} proj hdf5 json-c pcre
 Requires:        %{fullname}_%{pg_ver}-client = %{version}-%{release}
+Requires:        geos >= %{min_geos_ver}
 
 Requires(post):  chkconfig
 
@@ -262,5 +266,8 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Wed Nov 08 2023 Anton Novojilov <andy@essentialkaos.com> - 3.1.9-1
+- Minimal required version of GEOS set to 3.11
+
 * Thu Sep 21 2023 Anton Novojilov <andy@essentialkaos.com> - 3.1.9-0
 - https://git.osgeo.org/gitea/postgis/postgis/raw/tag/3.1.9/NEWS

--- a/specs/postgresql-15/postgis32.spec
+++ b/specs/postgresql-15/postgis32.spec
@@ -19,6 +19,8 @@
 %define pkgname         %{realname}-%{maj_ver}
 %define fullname        %{realname}32
 
+%define min_geos_ver    3.11
+
 %define __perl_requires   filter-requires-perl-Pg.sh
 
 ################################################################################
@@ -26,7 +28,7 @@
 Summary:         Geographic Information Systems Extensions to PostgreSQL %{pg_ver}
 Name:            %{fullname}_%{pg_ver}
 Version:         3.2.5
-Release:         0%{?dist}
+Release:         1%{?dist}
 License:         GPLv2+
 Group:           Applications/Databases
 URL:             https://www.postgis.net
@@ -40,7 +42,8 @@ BuildRoot:       %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires:   postgresql%{pg_ver}-devel = %{pg_low_fullver}
 BuildRequires:   postgresql%{pg_ver}-libs = %{pg_low_fullver}
-BuildRequires:   gcc-c++ geos-devel >= 3.9 chrpath make pcre-devel hdf5-devel
+BuildRequires:   geos-devel >= %{min_geos_ver}
+BuildRequires:   gcc-c++ chrpath make pcre-devel hdf5-devel
 BuildRequires:   proj-devel libtool flex json-c-devel libxml2-devel
 BuildRequires:   sqlite-devel libgeotiff-devel libpng-devel libtiff-devel
 
@@ -63,8 +66,9 @@ Requires:        gdal-libs >= 3
 %endif
 %endif
 
-Requires:        postgresql%{pg_ver} geos >= 3.9 proj hdf5 json-c pcre
+Requires:        postgresql%{pg_ver} proj hdf5 json-c pcre
 Requires:        %{fullname}_%{pg_ver}-client = %{version}-%{release}
+Requires:        geos >= %{min_geos_ver}
 
 Requires(post):  chkconfig
 
@@ -262,5 +266,8 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Wed Nov 08 2023 Anton Novojilov <andy@essentialkaos.com> - 3.2.5-1
+- Minimal required version of GEOS set to 3.11
+
 * Thu Sep 21 2023 Anton Novojilov <andy@essentialkaos.com> - 3.2.5-0
 - https://git.osgeo.org/gitea/postgis/postgis/raw/tag/3.2.5/NEWS

--- a/specs/postgresql-15/postgis33.spec
+++ b/specs/postgresql-15/postgis33.spec
@@ -19,6 +19,8 @@
 %define pkgname         %{realname}-%{maj_ver}
 %define fullname        %{realname}33
 
+%define min_geos_ver    3.11
+
 %define __perl_requires   filter-requires-perl-Pg.sh
 
 ################################################################################
@@ -26,7 +28,7 @@
 Summary:         Geographic Information Systems Extensions to PostgreSQL %{pg_ver}
 Name:            %{fullname}_%{pg_ver}
 Version:         3.3.4
-Release:         0%{?dist}
+Release:         1%{?dist}
 License:         GPLv2+
 Group:           Applications/Databases
 URL:             https://www.postgis.net
@@ -40,7 +42,8 @@ BuildRoot:       %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires:   postgresql%{pg_ver}-devel = %{pg_low_fullver}
 BuildRequires:   postgresql%{pg_ver}-libs = %{pg_low_fullver}
-BuildRequires:   gcc-c++ geos-devel >= 3.9 chrpath make pcre-devel hdf5-devel
+BuildRequires:   geos-devel >= %{min_geos_ver}
+BuildRequires:   gcc-c++ chrpath make pcre-devel hdf5-devel
 BuildRequires:   proj-devel libtool flex json-c-devel libxml2-devel
 BuildRequires:   sqlite-devel libgeotiff-devel libpng-devel libtiff-devel
 
@@ -63,8 +66,9 @@ Requires:        gdal-libs >= 3
 %endif
 %endif
 
-Requires:        postgresql%{pg_ver} geos >= 3.9 proj hdf5 json-c pcre
+Requires:        postgresql%{pg_ver} proj hdf5 json-c pcre
 Requires:        %{fullname}_%{pg_ver}-client = %{version}-%{release}
+Requires:        geos >= %{min_geos_ver}
 
 Requires(post):  chkconfig
 
@@ -271,5 +275,8 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Wed Nov 08 2023 Anton Novojilov <andy@essentialkaos.com> - 3.3.4-1
+- Minimal required version of GEOS set to 3.11
+
 * Thu Sep 21 2023 Anton Novojilov <andy@essentialkaos.com> - 3.3.4-0
 - https://git.osgeo.org/gitea/postgis/postgis/raw/tag/3.3.4/NEWS

--- a/specs/postgresql-15/postgis34.spec
+++ b/specs/postgresql-15/postgis34.spec
@@ -19,6 +19,8 @@
 %define pkgname         %{realname}-%{maj_ver}
 %define fullname        %{realname}34
 
+%define min_geos_ver    3.11
+
 %define __perl_requires   filter-requires-perl-Pg.sh
 
 ################################################################################
@@ -26,7 +28,7 @@
 Summary:         Geographic Information Systems Extensions to PostgreSQL %{pg_ver}
 Name:            %{fullname}_%{pg_ver}
 Version:         3.4.0
-Release:         0%{?dist}
+Release:         1%{?dist}
 License:         GPLv2+
 Group:           Applications/Databases
 URL:             https://www.postgis.net
@@ -40,7 +42,8 @@ BuildRoot:       %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires:   postgresql%{pg_ver}-devel = %{pg_low_fullver}
 BuildRequires:   postgresql%{pg_ver}-libs = %{pg_low_fullver}
-BuildRequires:   gcc-c++ geos-devel >= 3.9 chrpath make pcre-devel hdf5-devel
+BuildRequires:   geos-devel >= %{min_geos_ver}
+BuildRequires:   gcc-c++ chrpath make pcre-devel hdf5-devel
 BuildRequires:   proj-devel libtool flex json-c-devel libxml2-devel
 BuildRequires:   sqlite-devel libgeotiff-devel libpng-devel libtiff-devel
 
@@ -63,8 +66,9 @@ Requires:        gdal-libs >= 3
 %endif
 %endif
 
-Requires:        postgresql%{pg_ver} geos >= 3.9 proj hdf5 json-c pcre
+Requires:        postgresql%{pg_ver} proj hdf5 json-c pcre
 Requires:        %{fullname}_%{pg_ver}-client = %{version}-%{release}
+Requires:        geos >= %{min_geos_ver}
 
 Requires(post):  chkconfig
 
@@ -274,5 +278,8 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Wed Nov 08 2023 Anton Novojilov <andy@essentialkaos.com> - 3.4.0-1
+- Minimal required version of GEOS set to 3.11
+
 * Thu Sep 21 2023 Anton Novojilov <andy@essentialkaos.com> - 3.4.0-0
 - https://git.osgeo.org/gitea/postgis/postgis/raw/tag/3.4.0/NEWS

--- a/specs/postgresql-16/postgis34.spec
+++ b/specs/postgresql-16/postgis34.spec
@@ -19,6 +19,8 @@
 %define pkgname         %{realname}-%{maj_ver}
 %define fullname        %{realname}34
 
+%define min_geos_ver    3.11
+
 %define __perl_requires   filter-requires-perl-Pg.sh
 
 ################################################################################
@@ -26,7 +28,7 @@
 Summary:         Geographic Information Systems Extensions to PostgreSQL %{pg_ver}
 Name:            %{fullname}_%{pg_ver}
 Version:         3.4.0
-Release:         0%{?dist}
+Release:         1%{?dist}
 License:         GPLv2+
 Group:           Applications/Databases
 URL:             https://www.postgis.net
@@ -40,7 +42,8 @@ BuildRoot:       %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires:   postgresql%{pg_ver}-devel = %{pg_low_fullver}
 BuildRequires:   postgresql%{pg_ver}-libs = %{pg_low_fullver}
-BuildRequires:   gcc-c++ geos-devel >= 3.9 chrpath make pcre-devel hdf5-devel
+BuildRequires:   geos-devel >= %{min_geos_ver}
+BuildRequires:   gcc-c++ chrpath make pcre-devel hdf5-devel
 BuildRequires:   proj-devel libtool flex json-c-devel libxml2-devel
 BuildRequires:   sqlite-devel libgeotiff-devel libpng-devel libtiff-devel
 
@@ -63,8 +66,9 @@ Requires:        gdal-libs >= 3
 %endif
 %endif
 
-Requires:        postgresql%{pg_ver} geos >= 3.9 proj hdf5 json-c pcre
+Requires:        postgresql%{pg_ver} proj hdf5 json-c pcre
 Requires:        %{fullname}_%{pg_ver}-client = %{version}-%{release}
+Requires:        geos >= %{min_geos_ver}
 
 Requires(post):  chkconfig
 
@@ -274,5 +278,8 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Wed Nov 08 2023 Anton Novojilov <andy@essentialkaos.com> - 3.4.0-1
+- Minimal required version of GEOS set to 3.11
+
 * Thu Sep 21 2023 Anton Novojilov <andy@essentialkaos.com> - 3.4.0-0
 - https://git.osgeo.org/gitea/postgis/postgis/raw/tag/3.4.0/NEWS


### PR DESCRIPTION
### What's this PR about

Set minimal required version of GEOS to 3.11 for all versions of PostGIS. 

### Known build problems and traps

—

### TODO's:

- [x] Run [`perfecto`](https://kaos.sh/perfecto) check on your spec file
- [x] Write [`bibop`](https://kaos.sh/bibop) tests
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**Did you try to build the package with this spec?:** Yes
**Is this ready for review?:** Yes
