### PR TITLE
Update zlib to 1.3.1

### DIFF
--- a/specs/zlib.spec
+++ b/specs/zlib.spec
@@ -10,7 +10,7 @@
 
 Summary:        The compression and decompression library
 Name:           zlib
-Version:        1.3
+Version:        1.3.1
 Release:        0%{?dist}
 License:        zlib and Boost
 Group:          System Environment/Libraries
@@ -180,6 +180,15 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Thu Jan 25 2024 Anton Novojilov <andy@essentialkaos.com> - 1.3.1-0
+- Reject overflows of zip header fields in minizip
+- Fix bug in inflateSync() for data held in bit buffer
+- Add LIT_MEM define to use more memory for a small deflate speedup
+- Fix decision on the emission of Zip64 end records in minizip
+- Add bounds checking to ERR_MSG() macro, used by zError()
+- Neutralize zip file traversal attacks in miniunz
+- Fix a bug in ZLIB_DEBUG compiles in check_match()
+
 * Thu Dec 07 2023 Anton Novojilov <andy@essentialkaos.com> - 1.3-0
 - Building using K&R (pre-ANSI) function definitions is no longer supported
 - Fixed a bug in deflateBound() for level 0 and memLevel 9


### PR DESCRIPTION
### What's this PR about

Zlib updated to [1.3.1](https://github.com/madler/zlib/releases/tag/v1.3.1) with fixes for CVE-2014-9485 and CVE-2023-45853.[^1]

### Known build problems and traps

None.

### TODO's:

- [x] Run [`perfecto`](https://kaos.sh/perfecto) check on your spec file
- [x] Write [`bibop`](https://kaos.sh/bibop) tests
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**Did you try to build the package with this spec?:** Yes
**Is this ready for review?:** Yes

[^1]: https://twitter.com/_msw_/status/1749999077100855638
