### PR TITLE
Update golang to 1.22

### DIFF
--- a/specs/golang/golang.spec
+++ b/specs/golang/golang.spec
@@ -25,13 +25,13 @@
 %global gohostarch  386
 %endif
 
-%global go_api  1.21
+%global go_api  1.22
 
 ################################################################################
 
 Summary:        The Go Programming Language
 Name:           golang
-Version:        1.21.6
+Version:        1.22.0
 Release:        0%{?dist}
 License:        BSD
 Group:          Development/Languages
@@ -237,6 +237,9 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Wed Feb 07 2024 Anton Novojilov <andy@essentialkaos.com> - 1.22.0-0
+- https://go.dev/doc/go1.22
+
 * Wed Jan 10 2024 Anton Novojilov <andy@essentialkaos.com> - 1.21.6-0
 - https://github.com/golang/go/issues?q=milestone:Go1.21.6+label:CherryPickApproved
 

--- a/tests/golang/golang.recipe
+++ b/tests/golang/golang.recipe
@@ -5,8 +5,6 @@
 
 pkg golang golang-bin golang-src
 
-fast-finish yes
-
 var cache_dir  {WORKDIR}/.build-cache
 var goroot_dir /usr/lib/golang
 var tools_dir  {goroot_dir}/pkg/tool/{OS}_{ARCH_NAME}


### PR DESCRIPTION
### What's this PR about

Golang updated to [the latest version](https://go.dev/doc/go1.22).

### Known build problems and traps

Test for `openbsd/mips64` fails:

```
  Compile openbsd/mips64 → GOOS=openbsd GOARCH=mips64 go build -o test_openbsd_mips64 test.go
  └─ ✖  exit 0
     The process has exited with invalid exit code (1 ≠ 0)

     ┃ ☴ OUTPUT  The last 10 lines from command output
     ┃
     ┃ /usr/lib/golang/src/syscall/bpf_bsd.go:37:9: undefined: ioctlPtr
     ┃ /usr/lib/golang/src/syscall/bpf_bsd.go:47:9: undefined: ioctlPtr
     ┃ /usr/lib/golang/src/syscall/bpf_bsd.go:56:9: undefined: ioctlPtr
     ┃ /usr/lib/golang/src/syscall/bpf_bsd.go:65:9: undefined: ioctlPtr
     ┃ /usr/lib/golang/src/syscall/bpf_bsd.go:74:9: undefined: ioctlPtr
     ┃ /usr/lib/golang/src/syscall/bpf_bsd.go:89:9: undefined: ioctlPtr
     ┃ /usr/lib/golang/src/syscall/bpf_bsd.go:100:9: undefined: ioctlPtr
     ┃ /usr/lib/golang/src/syscall/bpf_bsd.go:110:9: undefined: ioctlPtr
     ┃ /usr/lib/golang/src/syscall/bpf_bsd.go:119:9: undefined: ioctlPtr
     ┃ /usr/lib/golang/src/syscall/bpf_bsd.go:119:9: too many errors
     ┖───────────────────────────────────────────────────────────────────────────────────────
```

### TODO's:

- [x] Run [`perfecto`](https://kaos.sh/perfecto) check on your spec file
- [x] Write [`bibop`](https://kaos.sh/bibop) tests
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**Did you try to build the package with this spec?:** Yes
**Is this ready for review?:** Yes
