### PR TITLE
Release 

### DIFF
--- a/release-info-gen.go
+++ b/release-info-gen.go
@@ -2,7 +2,7 @@ package main
 
 // ////////////////////////////////////////////////////////////////////////////////// //
 //                                                                                    //
-//                         Copyright (c) 2023 ESSENTIAL KAOS                          //
+//                         Copyright (c) 202 ESSENTIAL KAOS                          //
 //      Apache License, Version 2.0 <https://www.apache.org/licenses/LICENSE-2.0>     //
 //                                                                                    //
 // ////////////////////////////////////////////////////////////////////////////////// //
@@ -249,13 +249,13 @@ func listDeletions(changes Changes) {
 
 // parseChangeInfo parses change info
 func parseChangeInfo(line string) Change {
-	changeType := strutil.ReadField(line, 0, true, " ", "\t")
+	changeType := strutil.ReadField(line, 0, true, ' ', '\t')
 
 	switch changeType {
 	case TYPE_ADDED, TYPE_DELETED, TYPE_MODIFIED:
 		return Change{
 			Type: changeType,
-			File: strutil.ReadField(line, 1, true, " ", "\t"),
+			File: strutil.ReadField(line, 1, true, ' ', '\t'),
 		}
 	}
 
@@ -265,8 +265,8 @@ func parseChangeInfo(line string) Change {
 
 	return Change{
 		Type:       TYPE_RENAMED,
-		File:       strutil.ReadField(line, 2, true, " ", "\t"),
-		Source:     strutil.ReadField(line, 1, true, " ", "\t"),
+		File:       strutil.ReadField(line, 2, true, ' ', '\t'),
+		Source:     strutil.ReadField(line, 1, true, ' ', '\t'),
 		Similarity: extractSimilarityIndex(changeType),
 	}
 }

--- a/specs/adoptium/jdk11.spec
+++ b/specs/adoptium/jdk11.spec
@@ -8,14 +8,15 @@
 
 ################################################################################
 
-%define jdk_major  11.0.21
-%define jdk_minor  9
+%define jdk_major  11.0.22
+%define jdk_minor  7
+%define jdk_patch  .1
 
 %define install_dir  %{_prefix}/java/%{name}-%{version}
 %define jdk_bin_dir  %{install_dir}/bin
 %define jdk_man_dir  %{install_dir}/man/man1
 
-%define alt_priority  1167
+%define alt_priority  1168
 
 ################################################################################
 
@@ -23,7 +24,7 @@ Summary:      OpenJDK Runtime Environment (JDK 11)
 Name:         jdk11
 Epoch:        1
 Version:      %{jdk_major}
-Release:      %{jdk_minor}%{?dist}
+Release:      %{jdk_minor}%{jdk_patch}%{?dist}
 Group:        Development/Languages
 License:      ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib
 URL:          https://adoptium.net
@@ -110,6 +111,9 @@ deps="$deps --slave %{_sysconfdir}/profile.d/java.sh java-profile %{install_dir}
 ################################################################################
 
 %changelog
+* Fri Mar 22 2024 Anton Novojilov <andy@essentialkaos.com> - 11.0.22-7.1
+- https://adoptium.net/en-GB/temurin/release-notes/?version=jdk-11.0.22+7
+
 * Wed Dec 06 2023 Anton Novojilov <andy@essentialkaos.com> - 11.0.21-9
 - https://adoptium.net/en-GB/temurin/release-notes/?version=jdk-11.0.21+9
 

--- a/specs/adoptium/jdk17.spec
+++ b/specs/adoptium/jdk17.spec
@@ -8,14 +8,15 @@
 
 ################################################################################
 
-%define jdk_major  17.0.9
-%define jdk_minor  9
+%define jdk_major  17.0.10
+%define jdk_minor  7
+%define jdk_patch  %{nil}
 
 %define install_dir  %{_prefix}/java/%{name}-%{version}
 %define jdk_bin_dir  %{install_dir}/bin
 %define jdk_man_dir  %{install_dir}/man/man1
 
-%define alt_priority  1755
+%define alt_priority  1756
 
 ################################################################################
 
@@ -23,7 +24,7 @@ Summary:      OpenJDK Runtime Environment (JDK 17)
 Name:         jdk17
 Epoch:        1
 Version:      %{jdk_major}
-Release:      %{jdk_minor}%{?dist}
+Release:      %{jdk_minor}%{jdk_patch}%{?dist}
 Group:        Development/Languages
 License:      ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib
 URL:          https://adoptium.net
@@ -110,6 +111,9 @@ deps="$deps --slave %{_sysconfdir}/profile.d/java.sh java-profile %{install_dir}
 ################################################################################
 
 %changelog
+* Fri Mar 22 2024 Anton Novojilov <andy@essentialkaos.com> - 17.0.10-7
+- https://adoptium.net/en-GB/temurin/release-notes/?version=jdk-17.0.10+7
+
 * Wed Dec 06 2023 Anton Novojilov <andy@essentialkaos.com> - 17.0.9-9
 - https://adoptium.net/en-GB/temurin/release-notes/?version=jdk-17.0.9+9
 

--- a/specs/adoptium/jdk21.spec
+++ b/specs/adoptium/jdk21.spec
@@ -8,14 +8,15 @@
 
 ################################################################################
 
-%define jdk_major  21.0.1
-%define jdk_minor  12
+%define jdk_major  21.0.2
+%define jdk_minor  13
+%define jdk_patch  %{nil}
 
 %define install_dir  %{_prefix}/java/%{name}-%{version}
 %define jdk_bin_dir  %{install_dir}/bin
 %define jdk_man_dir  %{install_dir}/man/man1
 
-%define alt_priority  2155
+%define alt_priority  2156
 
 ################################################################################
 
@@ -23,7 +24,7 @@ Summary:      OpenJDK Runtime Environment (JDK 21)
 Name:         jdk21
 Epoch:        1
 Version:      %{jdk_major}
-Release:      %{jdk_minor}%{?dist}
+Release:      %{jdk_minor}%{jdk_patch}%{?dist}
 Group:        Development/Languages
 License:      ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib
 URL:          https://adoptium.net
@@ -110,5 +111,8 @@ deps="$deps --slave %{_sysconfdir}/profile.d/java.sh java-profile %{install_dir}
 ################################################################################
 
 %changelog
+* Fri Mar 22 2024 Anton Novojilov <andy@essentialkaos.com> - 21.0.2-13
+- https://adoptium.net/en-GB/temurin/release-notes/?version=jdk-21.0.2+13
+
 * Wed Dec 06 2023 Anton Novojilov <andy@essentialkaos.com> - 21.0.1-12
 - Initial build for kaos repository

--- a/specs/adoptium/jdk8.spec
+++ b/specs/adoptium/jdk8.spec
@@ -8,14 +8,15 @@
 
 ################################################################################
 
-%define jdk_major  392
-%define jdk_minor  b08
+%define jdk_major  402
+%define jdk_minor  b06
+%define jdk_patch  %{nil}
 
 %define install_dir  %{_prefix}/java/%{name}-%{version}
 %define jdk_bin_dir  %{install_dir}/bin
 %define jdk_man_dir  %{install_dir}/man/man1
 
-%define alt_priority  865
+%define alt_priority  866
 
 ################################################################################
 
@@ -23,7 +24,7 @@ Summary:      OpenJDK Runtime Environment (JDK 8)
 Name:         jdk8
 Epoch:        1
 Version:      1.8.0.%{jdk_major}
-Release:      %{jdk_minor}%{?dist}
+Release:      %{jdk_minor}%{jdk_patch}%{?dist}
 Group:        Development/Languages
 License:      ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib
 URL:          https://adoptium.net
@@ -111,6 +112,9 @@ deps="$deps --slave %{_sysconfdir}/profile.d/java.sh java-profile %{install_dir}
 ################################################################################
 
 %changelog
+* Fri Mar 22 2024 Anton Novojilov <andy@essentialkaos.com> - 1.8.0.402-b06
+- https://adoptium.net/en-GB/temurin/release-notes/?version=jdk8u402-b06
+
 * Wed Dec 06 2023 Anton Novojilov <andy@essentialkaos.com> - 1.8.0.392-b08
 - https://adoptium.net/en-GB/temurin/release-notes/?version=jdk8u392-b08
 

--- a/specs/adoptium/jre11.spec
+++ b/specs/adoptium/jre11.spec
@@ -8,14 +8,15 @@
 
 ################################################################################
 
-%define jdk_major  11.0.21
-%define jdk_minor  9
+%define jdk_major  11.0.22
+%define jdk_minor  7
+%define jdk_patch  .1
 
 %define install_dir  %{_prefix}/java/%{name}-%{version}
 %define jdk_bin_dir  %{install_dir}/bin
 %define jdk_man_dir  %{install_dir}/man/man1
 
-%define alt_priority  1117
+%define alt_priority  1118
 
 ################################################################################
 
@@ -23,7 +24,7 @@ Summary:      OpenJDK Runtime Environment (JRE 11)
 Name:         jre11
 Epoch:        1
 Version:      %{jdk_major}
-Release:      %{jdk_minor}%{?dist}
+Release:      %{jdk_minor}%{jdk_patch}%{?dist}
 Group:        Development/Languages
 License:      ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib
 URL:          https://adoptium.net
@@ -110,6 +111,9 @@ deps="$deps --slave %{_sysconfdir}/profile.d/java.sh java-profile %{install_dir}
 ################################################################################
 
 %changelog
+* Fri Mar 22 2024 Anton Novojilov <andy@essentialkaos.com> - 11.0.22-7.1
+- https://adoptium.net/en-GB/temurin/release-notes/?version=jdk-11.0.22+7
+
 * Wed Dec 06 2023 Anton Novojilov <andy@essentialkaos.com> - 11.0.21-9
 - https://adoptium.net/en-GB/temurin/release-notes/?version=jdk-11.0.21+9
 

--- a/specs/adoptium/jre17.spec
+++ b/specs/adoptium/jre17.spec
@@ -8,14 +8,15 @@
 
 ################################################################################
 
-%define jdk_major  17.0.9
-%define jdk_minor  9
+%define jdk_major  17.0.10
+%define jdk_minor  7
+%define jdk_patch  %{nil}
 
 %define install_dir  %{_prefix}/java/%{name}-%{version}
 %define jdk_bin_dir  %{install_dir}/bin
 %define jdk_man_dir  %{install_dir}/man/man1
 
-%define alt_priority  1705
+%define alt_priority  1706
 
 ################################################################################
 
@@ -23,7 +24,7 @@ Summary:      OpenJDK Runtime Environment (JRE 17)
 Name:         jre17
 Epoch:        1
 Version:      %{jdk_major}
-Release:      %{jdk_minor}%{?dist}
+Release:      %{jdk_minor}%{jdk_patch}%{?dist}
 Group:        Development/Languages
 License:      ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib
 URL:          https://adoptium.net
@@ -110,6 +111,9 @@ deps="$deps --slave %{_sysconfdir}/profile.d/java.sh java-profile %{install_dir}
 ################################################################################
 
 %changelog
+* Fri Mar 22 2024 Anton Novojilov <andy@essentialkaos.com> - 17.0.10-7
+- https://adoptium.net/en-GB/temurin/release-notes/?version=jdk-17.0.10+7
+
 * Wed Dec 06 2023 Anton Novojilov <andy@essentialkaos.com> - 17.0.9-9
 - https://adoptium.net/en-GB/temurin/release-notes/?version=jdk-17.0.9+9
 

--- a/specs/adoptium/jre21.spec
+++ b/specs/adoptium/jre21.spec
@@ -8,14 +8,15 @@
 
 ################################################################################
 
-%define jdk_major  21.0.1
-%define jdk_minor  12
+%define jdk_major  21.0.2
+%define jdk_minor  13
+%define jdk_patch  %{nil}
 
 %define install_dir  %{_prefix}/java/%{name}-%{version}
 %define jdk_bin_dir  %{install_dir}/bin
 %define jdk_man_dir  %{install_dir}/man/man1
 
-%define alt_priority  2100
+%define alt_priority  2101
 
 ################################################################################
 
@@ -23,7 +24,7 @@ Summary:      OpenJDK Runtime Environment (JRE 21)
 Name:         jre21
 Epoch:        1
 Version:      %{jdk_major}
-Release:      %{jdk_minor}%{?dist}
+Release:      %{jdk_minor}%{jdk_patch}%{?dist}
 Group:        Development/Languages
 License:      ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib
 URL:          https://adoptium.net
@@ -110,5 +111,8 @@ deps="$deps --slave %{_sysconfdir}/profile.d/java.sh java-profile %{install_dir}
 ################################################################################
 
 %changelog
+* Fri Mar 22 2024 Anton Novojilov <andy@essentialkaos.com> - 21.0.2-13
+- https://adoptium.net/en-GB/temurin/release-notes/?version=jdk-21.0.2+13
+
 * Wed Dec 06 2023 Anton Novojilov <andy@essentialkaos.com> - 21.0.1-12
 - Initial build for kaos repository

--- a/specs/adoptium/jre8.spec
+++ b/specs/adoptium/jre8.spec
@@ -8,14 +8,15 @@
 
 ################################################################################
 
-%define jdk_major  392
-%define jdk_minor  b08
+%define jdk_major  402
+%define jdk_minor  b06
+%define jdk_patch  %{nil}
 
 %define install_dir  %{_prefix}/java/%{name}-%{version}
 %define jdk_bin_dir  %{install_dir}/bin
 %define jdk_man_dir  %{install_dir}/man/man1
 
-%define alt_priority  815
+%define alt_priority  816
 
 ################################################################################
 
@@ -23,7 +24,7 @@ Summary:      OpenJDK Runtime Environment (JRE 8)
 Name:         jre8
 Epoch:        1
 Version:      1.8.0.%{jdk_major}
-Release:      %{jdk_minor}%{?dist}
+Release:      %{jdk_minor}%{jdk_patch}%{?dist}
 Group:        Development/Languages
 License:      ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib
 URL:          https://adoptium.net
@@ -111,6 +112,9 @@ deps="$deps --slave %{_sysconfdir}/profile.d/java.sh java-profile %{install_dir}
 ################################################################################
 
 %changelog
+* Fri Mar 22 2024 Anton Novojilov <andy@essentialkaos.com> - 1.8.0.402-b06
+- https://adoptium.net/en-GB/temurin/release-notes/?version=jdk8u402-b06
+
 * Wed Dec 06 2023 Anton Novojilov <andy@essentialkaos.com> - 1.8.0.392-b08
 - https://adoptium.net/en-GB/temurin/release-notes/?version=jdk8u392-b08
 

--- a/specs/autoconf.spec
+++ b/specs/autoconf.spec
@@ -6,7 +6,7 @@
 
 Summary:        A GNU tool for automatically configuring source code
 Name:           autoconf
-Version:        2.71
+Version:        2.72
 Release:        0%{?dist}
 License:        GPLv2+ and GFDL
 Group:          Development/Tools
@@ -82,5 +82,8 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Thu Apr 18 2024 Anton Novojilov <andy@essentialkaos.com> - 2.72-0
+- Updated to the latest stable release
+
 * Sat Jul 08 2023 Anton Novojilov <andy@essentialkaos.com> - 2.71-0
 - Initial build for EK repository

--- a/specs/createrepo_c.spec
+++ b/specs/createrepo_c.spec
@@ -21,7 +21,7 @@
 
 Summary:        Creates a common metadata repository
 Name:           createrepo_c
-Version:        1.0.2
+Version:        1.1.0
 Release:        0%{?dist}
 License:        GPLv2
 Group:          Development/Tools
@@ -188,6 +188,9 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Thu Apr 18 2024 Anton Novojilov <andy@essentialkaos.com> - 1.1.0-0
+- https://github.com/rpm-software-management/createrepo_c/compare/1.0.2...1.1.0
+
 * Wed Dec 06 2023 Anton Novojilov <andy@essentialkaos.com> - 1.0.2-0
 - https://github.com/rpm-software-management/createrepo_c/compare/1.0.1...1.0.2
 - Build with sanitizers disabled by default due to many leak alerts

--- a/specs/cronie.spec
+++ b/specs/cronie.spec
@@ -17,7 +17,7 @@
 
 Summary:         Cron daemon for executing programs at set times
 Name:            cronie
-Version:         1.7.1
+Version:         1.7.2
 Release:         0%{?dist}
 License:         MIT and BSD and ISC and GPLv2
 Group:           System Environment/Base
@@ -241,6 +241,9 @@ systemctl try-restart %{service_name}.service &>/dev/null || :
 ################################################################################
 
 %changelog
+* Thu Apr 18 2024 Anton Novojilov <andy@essentialkaos.com> - 1.7.2-0
+- https://github.com/cronie-crond/cronie/releases/tag/cronie-1.7.2
+
 * Wed Jan 17 2024 Anton Novojilov <andy@essentialkaos.com> - 1.7.1-0
 - https://github.com/cronie-crond/cronie/releases/tag/cronie-1.7.1
 

--- a/specs/curl.spec
+++ b/specs/curl.spec
@@ -10,7 +10,7 @@
 
 Summary:        Utility for getting files from remote servers
 Name:           curl
-Version:        8.5.0
+Version:        8.7.1
 Release:        0%{?dist}
 License:        MIT
 Group:          Applications/Internet
@@ -164,6 +164,12 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Tue Apr 16 2024 Anton Novojilov <andy@essentialkaos.com> - 8.7.1-0
+- https://curl.se/changes.html#8_7_1
+
+* Tue Apr 16 2024 Anton Novojilov <andy@essentialkaos.com> - 8.6.0-0
+- https://curl.se/changes.html#8_6_0
+
 * Wed Dec 06 2023 Anton Novojilov <andy@essentialkaos.com> - 8.5.0-0
 - https://curl.se/changes.html#8_5_0
 

--- a/specs/elixir.spec
+++ b/specs/elixir.spec
@@ -10,7 +10,7 @@
 
 Summary:        A modern approach to programming for the Erlang VM
 Name:           elixir
-Version:        1.16.0
+Version:        1.16.2
 Release:        0%{?dist}
 License:        ASL 2.0 and ERPL
 Group:          Development/Tools
@@ -82,6 +82,12 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Fri Mar 22 2024 Anton Novojilov <andy@essentialkaos.com> - 1.16.2-0
+- https://github.com/elixir-lang/elixir/releases/tag/v1.16.2
+
+* Fri Mar 22 2024 Anton Novojilov <andy@essentialkaos.com> - 1.16.1-0
+- https://github.com/elixir-lang/elixir/releases/tag/v1.16.1
+
 * Wed Jan 17 2024 Anton Novojilov <andy@essentialkaos.com> - 1.16.0-0
 - https://github.com/elixir-lang/elixir/releases/tag/v1.16.0
 

--- a/specs/erlang/erlang22.spec
+++ b/specs/erlang/erlang22.spec
@@ -23,7 +23,7 @@
 %define eprefix     %{_prefix}%{_lib32}
 %define ver_maj     22
 %define ver_min     3
-%define ver_patch   4.26
+%define ver_patch   4.27
 %define ver_suffix  %{ver_min}.%{ver_patch}
 %define ver_string  %{ver_maj}.%{ver_suffix}
 %define realname    erlang
@@ -1065,6 +1065,9 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Thu Mar 21 2024 Anton Novojilov <andy@essentialkaos.com> - 22.3.4.27-0
+- https://github.com/erlang/otp/releases/tag/OTP-22.3.4.27
+
 * Thu May 18 2023 Anton Novojilov <andy@essentialkaos.com> - 22.3.4.26-0
 - https://github.com/erlang/otp/releases/tag/OTP-22.3.4.26
 

--- a/specs/erlang/erlang23.spec
+++ b/specs/erlang/erlang23.spec
@@ -23,7 +23,7 @@
 %define eprefix     %{_prefix}%{_lib32}
 %define ver_maj     23
 %define ver_min     3
-%define ver_patch   4.19
+%define ver_patch   4.20
 %define ver_suffix  %{ver_min}.%{ver_patch}
 %define ver_string  %{ver_maj}.%{ver_suffix}
 %define realname    erlang
@@ -1066,6 +1066,9 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Thu Mar 21 2024 Anton Novojilov <andy@essentialkaos.com> - 23.3.4.20-0
+- https://github.com/erlang/otp/releases/tag/OTP-23.3.4.20
+
 * Wed Jun 21 2023 Anton Novojilov <andy@essentialkaos.com> - 23.3.4.19-0
 - https://github.com/erlang/otp/releases/tag/OTP-23.3.4.19
 

--- a/specs/erlang/erlang24.spec
+++ b/specs/erlang/erlang24.spec
@@ -23,12 +23,12 @@
 %define eprefix     %{_prefix}%{_lib32}
 %define ver_maj     24
 %define ver_min     3
-%define ver_patch   4.15
+%define ver_patch   4.16
 %define ver_suffix  %{ver_min}.%{ver_patch}
 %define ver_string  %{ver_maj}.%{ver_suffix}
 %define realname    erlang
 
-%define libre_ver   3.8.2
+%define libre_ver   3.8.3
 
 ################################################################################
 
@@ -1042,6 +1042,10 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Thu Mar 21 2024 Anton Novojilov <andy@essentialkaos.com> - 24.3.4.16-0
+- https://github.com/erlang/otp/releases/tag/OTP-24.3.4.16
+- LibreSSL updated to 3.8.3
+
 * Thu Dec 21 2023 Anton Novojilov <andy@essentialkaos.com> - 24.3.4.15-0
 - https://github.com/erlang/otp/releases/tag/OTP-24.3.4.15
 - LibreSSL updated to 3.8.2

--- a/specs/erlang/erlang24.spec
+++ b/specs/erlang/erlang24.spec
@@ -23,12 +23,12 @@
 %define eprefix     %{_prefix}%{_lib32}
 %define ver_maj     24
 %define ver_min     3
-%define ver_patch   4.16
+%define ver_patch   4.17
 %define ver_suffix  %{ver_min}.%{ver_patch}
 %define ver_string  %{ver_maj}.%{ver_suffix}
 %define realname    erlang
 
-%define libre_ver   3.8.3
+%define libre_ver   3.8.4
 
 ################################################################################
 
@@ -1042,6 +1042,10 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Tue Apr 16 2024 Anton Novojilov <andy@essentialkaos.com> - 24.3.4.17-0
+- https://github.com/erlang/otp/releases/tag/OTP-24.3.4.17
+- LibreSSL updated to 3.8.4
+
 * Thu Mar 21 2024 Anton Novojilov <andy@essentialkaos.com> - 24.3.4.16-0
 - https://github.com/erlang/otp/releases/tag/OTP-24.3.4.16
 - LibreSSL updated to 3.8.3

--- a/specs/erlang/erlang25.spec
+++ b/specs/erlang/erlang25.spec
@@ -23,12 +23,12 @@
 %define eprefix     %{_prefix}%{_lib32}
 %define ver_maj     25
 %define ver_min     3
-%define ver_patch   2.8
+%define ver_patch   2.10
 %define ver_suffix  %{ver_min}.%{ver_patch}
 %define ver_string  %{ver_maj}.%{ver_suffix}
 %define realname    erlang
 
-%define libre_ver   3.8.2
+%define libre_ver   3.8.3
 
 ################################################################################
 
@@ -1033,6 +1033,10 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Thu Mar 21 2024 Anton Novojilov <andy@essentialkaos.com> - 25.3.2.10-0
+- https://github.com/erlang/otp/releases/tag/OTP-25.3.2.10
+- LibreSSL updated to 3.8.3
+
 * Thu Dec 21 2023 Anton Novojilov <andy@essentialkaos.com> - 25.3.2.8-0
 - https://github.com/erlang/otp/releases/tag/OTP-25.3.2.8
 - LibreSSL updated to 3.8.2

--- a/specs/erlang/erlang25.spec
+++ b/specs/erlang/erlang25.spec
@@ -23,12 +23,12 @@
 %define eprefix     %{_prefix}%{_lib32}
 %define ver_maj     25
 %define ver_min     3
-%define ver_patch   2.10
+%define ver_patch   2.11
 %define ver_suffix  %{ver_min}.%{ver_patch}
 %define ver_string  %{ver_maj}.%{ver_suffix}
 %define realname    erlang
 
-%define libre_ver   3.8.3
+%define libre_ver   3.8.4
 
 ################################################################################
 
@@ -1033,6 +1033,10 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Tue Apr 16 2024 Anton Novojilov <andy@essentialkaos.com> - 25.3.2.11-0
+- https://github.com/erlang/otp/releases/tag/OTP-25.3.2.11
+- LibreSSL updated to 3.8.4
+
 * Thu Mar 21 2024 Anton Novojilov <andy@essentialkaos.com> - 25.3.2.10-0
 - https://github.com/erlang/otp/releases/tag/OTP-25.3.2.10
 - LibreSSL updated to 3.8.3

--- a/specs/erlang/erlang26.spec
+++ b/specs/erlang/erlang26.spec
@@ -23,12 +23,12 @@
 %define eprefix     %{_prefix}%{_lib32}
 %define ver_maj     26
 %define ver_min     2
-%define ver_patch   1
+%define ver_patch   3
 %define ver_suffix  %{ver_min}.%{ver_patch}
 %define ver_string  %{ver_maj}.%{ver_suffix}
 %define realname    erlang
 
-%define libre_ver   3.8.2
+%define libre_ver   3.8.3
 
 ################################################################################
 
@@ -1033,6 +1033,10 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Thu Mar 21 2024 Anton Novojilov <andy@essentialkaos.com> - 26.2.3-0
+- https://github.com/erlang/otp/releases/tag/OTP-26.2.3
+- LibreSSL updated to 3.8.3
+
 * Thu Dec 21 2023 Anton Novojilov <andy@essentialkaos.com> - 26.2.1-0
 - https://github.com/erlang/otp/releases/tag/OTP-26.2.1
 - LibreSSL updated to 3.8.2

--- a/specs/erlang/erlang26.spec
+++ b/specs/erlang/erlang26.spec
@@ -23,12 +23,12 @@
 %define eprefix     %{_prefix}%{_lib32}
 %define ver_maj     26
 %define ver_min     2
-%define ver_patch   3
+%define ver_patch   4
 %define ver_suffix  %{ver_min}.%{ver_patch}
 %define ver_string  %{ver_maj}.%{ver_suffix}
 %define realname    erlang
 
-%define libre_ver   3.8.3
+%define libre_ver   3.8.4
 
 ################################################################################
 
@@ -1033,6 +1033,10 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Tue Apr 16 2024 Anton Novojilov <andy@essentialkaos.com> - 26.2.4-0
+- https://github.com/erlang/otp/releases/tag/OTP-26.2.4
+- LibreSSL updated to 3.8.4
+
 * Thu Mar 21 2024 Anton Novojilov <andy@essentialkaos.com> - 26.2.3-0
 - https://github.com/erlang/otp/releases/tag/OTP-26.2.3
 - LibreSSL updated to 3.8.3

--- a/specs/etcd.spec
+++ b/specs/etcd.spec
@@ -10,7 +10,7 @@
 
 Summary:        Distributed reliable key-value store for the most critical data of a distributed system
 Name:           etcd
-Version:        3.5.11
+Version:        3.5.13
 Release:        0%{?dist}
 Group:          Applications/Internet
 License:        APLv2
@@ -91,6 +91,9 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Thu Apr 18 2024 Anton Novojilov <andy@essentialkaos.com> - 3.5.13-0
+- https://github.com/etcd-io/etcd/releases/tag/v3.5.13
+
 * Thu Dec 07 2023 Anton Novojilov <andy@essentialkaos.com> - 3.5.11-0
 - https://github.com/etcd-io/etcd/releases/tag/v3.5.11
 

--- a/specs/fish.spec
+++ b/specs/fish.spec
@@ -6,7 +6,7 @@
 
 Summary:        Friendly interactive shell (FISh)
 Name:           fish
-Version:        3.7.0
+Version:        3.7.1
 Release:        0%{?dist}
 License:        GPL2
 Group:          System Environment/Shells
@@ -94,6 +94,9 @@ fi
 ################################################################################
 
 %changelog
+* Mon Mar 25 2024 Anton Novojilov <andy@essentialkaos.com> - 3.7.1-0
+- https://github.com/fish-shell/fish-shell/releases/tag/3.7.1
+
 * Wed Jan 17 2024 Anton Novojilov <andy@essentialkaos.com> - 3.7.0-0
 - https://github.com/fish-shell/fish-shell/releases/tag/3.7.0
 

--- a/specs/git.spec
+++ b/specs/git.spec
@@ -15,7 +15,7 @@
 
 Summary:        Core git tools
 Name:           git
-Version:        2.43.0
+Version:        2.44.0
 Release:        0%{?dist}
 License:        GPL
 Group:          Development/Tools
@@ -283,6 +283,18 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Thu Apr 18 2024 Anton Novojilov <andy@essentialkaos.com> - 2.44.0-0
+- https://github.com/git/git/blob/master/Documentation/RelNotes/2.44.0.txt
+
+* Thu Apr 18 2024 Anton Novojilov <andy@essentialkaos.com> - 2.43.3-0
+- https://github.com/git/git/blob/master/Documentation/RelNotes/2.43.3.txt
+
+* Thu Apr 18 2024 Anton Novojilov <andy@essentialkaos.com> - 2.43.2-0
+- https://github.com/git/git/blob/master/Documentation/RelNotes/2.43.2.txt
+
+* Thu Apr 18 2024 Anton Novojilov <andy@essentialkaos.com> - 2.43.1-0
+- https://github.com/git/git/blob/master/Documentation/RelNotes/2.43.1.txt
+
 * Wed Dec 06 2023 Anton Novojilov <andy@essentialkaos.com> - 2.43.0-0
 - https://github.com/git/git/blob/master/Documentation/RelNotes/2.43.0.txt
 

--- a/specs/goaccess/SOURCES/webkaos-formats.patch
+++ b/specs/goaccess/SOURCES/webkaos-formats.patch
@@ -1,9 +1,9 @@
-diff -urN goaccess-1.5.7-orig/config/goaccess.conf goaccess-1.5.7/config/goaccess.conf
---- goaccess-1.5.7-orig/config/goaccess.conf	2022-04-28 03:53:10.000000000 +0300
-+++ goaccess-1.5.7/config/goaccess.conf	2022-08-22 13:24:54.000000000 +0300
-@@ -100,6 +100,20 @@
- # CADDY JSON Structured
- #log-format {ts:"%x.%^",request:{remote_ip:"%h",proto:"%H",method:"%m",host:"%v",uri:"%U",headers:{"User-Agent":["%u","%^"]},tls:{cipher_suite:"%k",proto:"%K"}},duration:"%T",size:"%b",status:"%s",resp_headers:{"Content-Type":["%M;%^"]}}
+diff --color -urN goaccess-1.9.2-orig/config/goaccess.conf goaccess-1.9.2/config/goaccess.conf
+--- goaccess-1.9.2-orig/config/goaccess.conf	2024-04-09 02:11:20.000000000 +0300
++++ goaccess-1.9.2/config/goaccess.conf	2024-04-18 15:02:31.000000000 +0300
+@@ -118,6 +118,20 @@
+ # Traefik CLF flavor
+ #log-format %h - %e [%d:%t %^] "%r" %s %b "%R" "%u" %^ "%v" "%U" %Lms
  
 +# WEBKAOS basic formats
 +#time-format %T

--- a/specs/goaccess/goaccess.spec
+++ b/specs/goaccess/goaccess.spec
@@ -6,7 +6,7 @@
 
 Summary:        Real-time web log analyzer and interactive viewer
 Name:           goaccess
-Version:        1.8.1
+Version:        1.9.2
 Release:        0%{?dist}
 Group:          Development/Tools
 License:        GPLv2+
@@ -61,7 +61,7 @@ rm -rf %{buildroot}
 
 %files
 %defattr(-,root,root,-)
-%doc AUTHORS ChangeLog COPYING README TODO
+%doc AUTHORS ChangeLog COPYING README.md TODO
 %config(noreplace) %{_sysconfdir}/%{name}/browsers.list
 %config(noreplace) %{_sysconfdir}/%{name}/podcast.list
 %config(noreplace) %{_sysconfdir}/%{name}/%{name}.conf
@@ -72,6 +72,9 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Thu Apr 18 2024 Anton Novojilov <andy@essentialkaos.com> - 1.9.2-0
+- https://goaccess.io/release-notes#release-1.9.2
+
 * Wed Dec 06 2023 Anton Novojilov <andy@essentialkaos.com> - 1.8.1-0
 - https://goaccess.io/release-notes#release-1.8.1
 

--- a/specs/golang/golang.spec
+++ b/specs/golang/golang.spec
@@ -31,7 +31,7 @@
 
 Summary:        The Go Programming Language
 Name:           golang
-Version:        1.22.1
+Version:        1.22.2
 Release:        0%{?dist}
 License:        BSD
 Group:          Development/Languages
@@ -237,6 +237,9 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Thu Apr 04 2024 Anton Novojilov <andy@essentialkaos.com> - 1.22.2-0
+- https://github.com/golang/go/issues?q=milestone:Go1.22.2+label:CherryPickApproved
+
 * Tue Mar 05 2024 Anton Novojilov <andy@essentialkaos.com> - 1.22.1-0
 - https://github.com/golang/go/issues?q=milestone:Go1.22.1+label:CherryPickApproved
 

--- a/specs/gradle.spec
+++ b/specs/gradle.spec
@@ -14,7 +14,7 @@
 
 Summary:    A powerful build system for the JVM
 Name:       gradle
-Version:    8.5
+Version:    8.7
 Release:    0%{?dist}
 License:    ASL 2.0
 Group:      Development/Tools
@@ -77,6 +77,9 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Thu Apr 18 2024 Anton Novojilov <andy@essentialkaos.com> - 8.7-0
+- https://docs.gradle.org/8.7/release-notes.html
+
 * Thu Dec 07 2023 Anton Novojilov <andy@essentialkaos.com> - 8.5-0
 - https://docs.gradle.org/8.5/release-notes.html
 

--- a/specs/haproxy/haproxy.spec
+++ b/specs/haproxy/haproxy.spec
@@ -22,7 +22,7 @@
 
 Name:           haproxy
 Summary:        TCP/HTTP reverse proxy for high availability environments
-Version:        2.8.6
+Version:        2.8.9
 Release:        0%{?dist}
 License:        GPLv2+
 URL:            https://haproxy.1wt.eu
@@ -229,6 +229,93 @@ fi
 ################################################################################
 
 %changelog
+* Tue Apr 16 2024 Anton Novojilov <andy@essentialkaos.com> - 2.8.9-0
+- BUILD: proxy: Replace free_logformat_list() to manually release log-format
+
+* Tue Apr 16 2024 Anton Novojilov <andy@essentialkaos.com> - 2.8.8-0
+- MINOR: mux-h2: add a counter of "glitches" on a connection
+- BUG/MINOR: mux-h2: count rejected DATA frames against the connection's flow
+  control
+- MINOR: mux-h2: count excess of CONTINUATION frames as a glitch
+- MINOR: mux-h2: count late reduction of INITIAL_WINDOW_SIZE as a glitch
+- MINOR: mux-h2: always use h2c_report_glitch()
+- MEDIUM: mux-h2: allow to set the glitches threshold to kill a connection
+- MINOR: connection: add a new mux_ctl to report number of connection glitches
+- MINOR: mux-h2: implement MUX_CTL_GET_GLITCHES
+- MINOR: connection: add sample fetches to report per-connection glitches
+- BUG/MAJOR: promex: fix crash on deleted server
+- BUG/MINOR: quic: reject unknown frame type
+- BUG/MINOR: quic: reject HANDSHAKE_DONE as server
+- BUG/MINOR: qpack: reject invalid increment count decoding
+- BUG/MINOR: qpack: reject invalid dynamic table capacity
+- DOC: quic: Missing tuning setting in "Global parameters"
+- BUG/MEDIUM: applet: Immediately free appctx on early error
+- BUG/MEDIUM: hlua: Be able to garbage collect uninitialized lua sockets
+- BUG/MEDIUM: hlua: Don't loop if a lua socket does not consume received data
+- BUG/MEDIUM: quic: fix transient send error with listener socket
+- DOC: quic: fix recommandation for bind on multiple address
+- MINOR: quic: warn on bind on multiple addresses if no IP_PKTINFO support
+- BUG/MINOR: ist: allocate nul byte on istdup
+- BUG/MINOR: stats: drop srv refcount on early release
+- BUG/MAJOR: server: fix stream crash due to deleted server
+- BUG/MINOR: quic: fix output of show quic
+- BUG/MINOR: ist: only store NUL byte on succeeded alloc
+- BUG/MINOR: ssl/cli: duplicate cleaning code in cli_parse_del_crtlist
+- LICENSE: event_hdl: fix GPL license version
+- LICENSE: http_ext: fix GPL license version
+- DOC: configuration: clarify ciphersuites usage
+- BUG/MINOR: config/quic: Alert about PROXY protocol use on a QUIC listener
+- BUG/MINOR: hlua: Fix log level to the right value when set via
+  TXN:set_loglevel
+- MINOR: hlua: Be able to disable logging from lua
+- BUG/MINOR: tools: seed the statistical PRNG slightly better
+- BUG/MINOR: hlua: fix unsafe lua_tostring() usage with empty stack
+- BUG/MINOR: hlua: don't use lua_tostring() from unprotected contexts
+- BUG/MINOR: hlua: fix possible crash in hlua_filter_new() under load
+- BUG/MINOR: hlua: improper lock usage in hlua_filter_callback()
+- BUG/MINOR: hlua: improper lock usage in hlua_filter_new()
+- BUG/MEDIUM: hlua: improper lock usage with SET_SAFE_LJMP()
+- BUG/MAJOR: hlua: improper lock usage with hlua_ctx_resume()
+- BUG/MINOR: hlua: don't call ha_alert() in hlua_event_subscribe()
+- BUG/MINOR: sink: fix a race condition in the TCP log forwarding code
+- CI: skip scheduled builds on forks
+- BUG/MINOR: ssl/cli: typo in new ssl crl-file CLI description
+- BUG/MINOR: cfgparse: report proper location for log-format-sd errors
+- BUILD: solaris: fix compilation errors
+- DOC: configuration: clarify ciphersuites usage (V2)
+- BUG/MINOR: ssl: fix possible ctx memory leak in sample_conv_aes_gcm()
+- BUG/MINOR: hlua: segfault when loading the same filter from different contexts
+- BUG/MINOR: hlua: missing lock in hlua_filter_new()
+- BUG/MINOR: hlua: fix missing lock in hlua_filter_delete()
+- DEBUG: lua: precisely identify if stream is stuck inside lua or not
+- MINOR: hlua: use accessors for stream hlua ctx
+- BUG/MEDIUM: hlua: streams don't support mixing lua-load with
+  lua-load-per-thread (2nd try)
+- BUG/MINOR: listener: Wake proxy's mngmt task up if necessary on session
+  release
+- BUG/MINOR: listener: Don't schedule frontend without task in
+  listener_release()
+- BUG/MEDIUM: spoe: Don't rely on stream's expiration to detect processing
+  timeout
+- BUG/MINOR: spoe: Be sure to be able to quickly close IDLE applets on soft-stop
+- CI: temporarily adjust kernel entropy to work with ASAN/clang
+- BUG/MEDIUM: spoe: Return an invalid frame on recv if size is too small
+- BUG/MINOR: session: ensure conn owner is set after insert into session
+- BUG/MEDIUM: ssl: Fix crash in ocsp-update log function
+- BUG/MINOR: mux-quic: close all QCS before freeing QCC tasklet
+- BUG/MEDIUM: mux-fcgi: Properly handle EOM flag on end-of-trailers HTX block
+- OPTIM: http_ext: avoid useless copy in http_7239_extract_{ipv4,ipv6}
+- BUG/MINOR: server: 'source' interface ignored from 'default-server' directive
+- BUG/MINOR: ssl: Wrong ocsp-update "incompatibility" error message
+- BUG/MINOR: ssl: Detect more 'ocsp-update' incompatibilities
+- BUG/MINOR: server: fix persistence cookie for dynamic servers
+- MINOR: server: allow cookie for dynamic servers
+- MINOR: cli: Remove useless loop on commands to find unescaped semi-colon
+- BUG/MEDIUM: cli: Warn if pipelined commands are delimited by a \n
+- BUG/MINOR: server: ignore 'enabled' for dynamic servers
+- BUG/MINOR: backend: properly handle redispatch 0
+- BUG/MINOR: proxy: fix logformat expression leak in use_backend rules
+
 * Fri Mar 22 2024 Anton Novojilov <andy@essentialkaos.com> - 2.8.7-0
 - BUG/MAJOR: ssl/ocsp: crash with ocsp when old process exit or using ocsp CLI
 

--- a/specs/haproxy/haproxy.spec
+++ b/specs/haproxy/haproxy.spec
@@ -13,8 +13,8 @@
 %define hp_datadir   %{_datadir}/%{name}
 
 %define lua_ver       5.4.6
-%define pcre_ver      10.42
-%define openssl_ver   3.1.4
+%define pcre_ver      10.43
+%define openssl_ver   3.1.5
 %define ncurses_ver   6.4
 %define readline_ver  8.2
 
@@ -22,7 +22,7 @@
 
 Name:           haproxy
 Summary:        TCP/HTTP reverse proxy for high availability environments
-Version:        2.8.5
+Version:        2.8.6
 Release:        0%{?dist}
 License:        GPLv2+
 URL:            https://haproxy.1wt.eu
@@ -93,7 +93,7 @@ pushd openssl-%{openssl_ver}
   mkdir build
   # perfecto:ignore
   ./config --prefix=$(pwd)/build no-shared no-threads
-  %{__make}
+  %{__make} %{?_smp_mflags}
   %{__make} install_sw
 popd
 
@@ -229,6 +229,152 @@ fi
 ################################################################################
 
 %changelog
+* Fri Mar 22 2024 Anton Novojilov <andy@essentialkaos.com> - 2.8.7-0
+- BUG/MAJOR: ssl/ocsp: crash with ocsp when old process exit or using ocsp CLI
+
+* Thu Mar 21 2024 Anton Novojilov <andy@essentialkaos.com> - 2.8.6-0
+- DOC: configuration: typo req.ssl_hello_type
+- BUG/MINOR: mworker/cli: fix set severity-output support
+- BUG/MEDIUM: quic: Possible buffer overflow when building TLS records
+- BUG/MEDIUM: quic: QUIC CID removed from tree without locking
+- BUG/MEDIUM: mux-h2: Report too large HEADERS frame only when rxbuf is empty
+- BUG/MINOR: resolvers: default resolvers fails when network not configured
+- DOC: config: Update documentation about local haproxy response
+- MINOR: stats: store the parent proxy in stats ctx (http)
+- BUG/MEDIUM: stats: unhandled switching rules with TCP frontend
+- BUG/MINOR: mux-quic: always report error to SC on RESET_STREAM emission
+- BUG/MINOR: quic: Wrong keylog callback setting.
+- BUG/MINOR: quic: Missing call to TLS message callbacks
+- MINOR: h3: check connection error during sending
+- BUG/MINOR: h3: close connection on header list too big
+- BUG/MINOR: h3: properly handle alloc failure on finalize
+- BUG/MINOR: h3: close connection on sending alloc errors
+- CLEANUP: quic: Remaining useless code into server part
+- BUG/MEDIUM: h3: fix incorrect snd_buf return value
+- BUG/MEDIUM: stconn: Forward shutdown on write timeout only if it is
+  forwardable
+- BUG/MEDIUM: spoe: Never create new spoe applet if there is no server up
+- MINOR: mux-h2: support limiting the total number of H2 streams per connection
+- DOC: configuration: corrected description of keyword
+  tune.ssl.ocsp-update.mindelay
+- BUG/MINOR: mux-quic: do not prevent non-STREAM sending on flow control
+- BUG/MINOR: mux-h2: also count streams for refused ones
+- BUG/MEDIUM: quic: keylog callback not called (USE_OPENSSL_COMPAT)
+- MINOR: compiler: add a new DO_NOT_FOLD() macro to prevent code folding
+- MINOR: debug: make sure calls to ha_crash_now() are never merged
+- MINOR: debug: make ABORT_NOW() store the caller's line number when using abort
+- MINOR: debug: make BUG_ON() catch build errors even without DEBUG_STRICT
+- MINOR: mux-h2/traces: also suggest invalid header upon parsing error
+- MINOR: mux-h2/traces: explicitly show the error/refused stream states
+- MINOR: mux-h2/traces: clarify the "rejected H2 request" event
+- BUG/MEDIUM: mux-h2: refine connection vs stream error on headers
+- MINOR: mux-h2/traces: add a missing trace on connection WU with negative inc
+- REGTESTS: add a test to ensure map-ordering is preserved
+- BUG/MEDIUM: cli: some err/warn msg dumps add LR into CSV output on stat's CLI
+- BUG/MINOR: vars/cli: fix missing LF after "get var" output
+- BUG/MEDIUM: cli: fix once for all the problem of missing trailing LFs
+- BUG/MINOR: jwt: fix jwt_verify crash on 32-bit archs
+- BUG/MEDIUM: pool: fix rare risk of deadlock in pool_flush()
+- BUG/MEDIUM: stconn: Allow expiration update when READ/WRITE event is pending
+- BUG/MEDIUM: stconn: Don't check pending shutdown to wake an applet up
+- BUG/MINOR: h1: Don't support LF only at the end of chunks
+- BUG/MEDIUM: h1: Don't support LF only to mark the end of a chunk size
+- BUG/MINOR: h1-htx: properly initialize the err_pos field
+- BUG/MEDIUM: h1: always reject the NUL character in header values
+- BUG/MAJOR: ssl_sock: Always clear retry flags in read/write functions
+- BUG/MINOR: ssl: Fix error message after ssl_sock_load_ocsp call
+- BUG/MINOR: ssl: Duplicate ocsp update mode when dup'ing ckch
+- BUG/MINOR: ssl: Clear the ckch instance when deleting a crt-list line
+- MINOR: ssl: Use OCSP_CERTID instead of ckch_store in ckch_store_build_certid
+- BUG/MEDIUM: ocsp: Separate refcount per instance and per store
+- BUG/MINOR: ssl: Destroy ckch instances before the store during deinit
+- BUG/MINOR: ssl: Reenable ocsp auto-update after an "add ssl crt-list"
+- REGTESTS: ssl: Fix empty line in cli command input
+- REGTESTS: ssl: Add OCSP related tests
+- BUG/MEDIUM: ssl: Fix crash when calling "update ssl ocsp-response" when an
+  update is ongoing
+- BUG/MINOR: h3: fix checking on NULL Tx buffer
+- BUG/MEDIUM: mux-quic: report early error on stream
+- CLEANUP: quic: Remove unused CUBIC_BETA_SCALE_FACTOR_SHIFT macro.
+- MINOR: quic: Stop hardcoding a scale shifting value
+  (CUBIC_BETA_SCALE_FACTOR_SHIFT)
+- MINOR: quic: extract qc_stream_buf free in a dedicated function
+- BUG/MEDIUM: quic: remove unsent data from qc_stream_desc buf
+- MINOR: h3: add traces for stream sending function
+- BUG/MEDIUM: h3: do not crash on invalid response status code
+- BUG/MEDIUM: qpack: allow 6xx..9xx status codes
+- BUG/MEDIUM: quic: fix crash on invalid qc_stream_buf_free() BUG_ON
+- BUG/MINOR: quic: Wrong ack ranges handling when reaching the limit.
+- CLEANUP: quic: Code clarifications for QUIC CUBIC (RFC 9438)
+- BUG/MINOR: quic: fix possible integer wrap around in cubic window calculation
+- MINOR: quic: Stop using 1024th of a second.
+- BUG/MEDIUM: quic: Wrong K CUBIC calculation.
+- MINOR: quic: Update K CUBIC calculation (RFC 9438)
+- MINOR: quic: Dynamic packet reordering threshold
+- MINOR: quic: Add a counter for reordered packets
+- MINOR: errors: ha_alert() and ha_warning() uses warn_exec_path()
+- BUG/MINOR: diag: always show the version before dumping a diag warning
+- BUG/MINOR: diag: run the final diags before quitting when using -c
+- MINOR: ext-check: add an option to preserve environment variables
+- BUG/MINOR: ext-check: cannot use without preserve-env
+- BUILD: address a few remaining calloc(size, n) cases
+- DOC: configuration: clarify http-request wait-for-body
+- DOC: httpclient: add dedicated httpclient section
+- DOC: install: recommend pcre2
+- DOC: internal: update missing data types in peers-v2.0.txt
+- CI: Update to actions/cache@v4
+- DEV: makefile: add a new "range" target to iteratively build all commits
+- DEV: makefile: fix POSIX compatibility for "range" target
+
+* Wed Jan 17 2024 Anton Novojilov <andy@essentialkaos.com> - 2.8.5-0
+- BUG/MAJOR: quic: complete thread migration before tcp-rules
+- BUG/MEDIUM: mux-h2: fail earlier on malloc in takeover()
+- BUG/MEDIUM: mux-h1: fail earlier on malloc in takeover()
+- BUG/MEDIUM: mux-fcgi: fail earlier on malloc in takeover()
+- BUG/MINOR: stream/cli: report correct stream age in "show sess"
+- MINOR: stktable: add stktable_deinit function
+- BUG/MINOR: proxy/stktable: missing frees on proxy cleanup
+- REGTESTS: http: add a test to validate chunked responses delivery
+- BUG/MINOR: startup: set GTUNE_SOCKET_TRANSFER correctly
+- BUG/MINOR: sock: mark abns sockets as non-suspendable and always unbind them
+- BUG/MEDIUM: quic: Possible crash for connections to be killed
+- BUG/MINOR: quic: Possible RX packet memory leak under heavy load
+- BUG/MINOR: server: do not leak default-server in defaults sections
+- DOC: 51d: updated 51Degrees repo URL for v3.2.10
+- DOC: config: fix timeout check inheritance restrictions
+- REGTESTS: connection: disable http_reuse_be_transparent.vtc if !TPROXY
+- DOC: lua: add sticktable class reference from Proxy.stktable
+- DOC: lua: fix Proxy.get_mode() output
+- BUG/MINOR: quic: fix CONNECTION_CLOSE_APP encoding
+- BUG/MINOR: compression: possible NULL dereferences in
+  comp_prepare_compress_request()
+- BUG/MEDIUM: master/cli: Properly pin the master CLI on thread 1 / group 1
+- BUG/MINOR: h3: fix TRAILERS encoding
+- BUG/MINOR: h3: always reject PUSH_PROMISE
+- DOC: config: fix missing characters in set-spoe-group action
+- BUG/MINOR: quic_tp: fix preferred_address decoding
+- BUG/MINOR: config: Stopped parsing upon unmatched environment variables
+- BUG/MINOR: cfgparse-listen: fix warning being reported as an alert
+- DOC: config: specify supported sections for "max-session-srv-conns"
+- DOC: config: add matrix entry for "max-session-srv-conns"
+- DOC: config: fix monitor-fail typo
+- REGTESTS: sample: Test the behavior of consecutive delimiters for the field
+  converter
+- BUG/MINOR: sample: Make the `word` converter compatible with `-m found`
+- DOC: Clarify the differences between field() and word()
+- BUG/MEDIUM: peers: fix partial message decoding
+- BUG/MINOR: cache: Remove incomplete entries from the cache when stream
+  is closed
+- BUG/MEDIUM: quic: Possible crash during retransmissions and heavy load
+- BUG/MINOR: quic: Possible leak of TX packets under heavy load
+- BUG/MINOR: quic: Missing QUIC connection path member initialization
+- BUG/MINOR: quic: Packet number spaces too lately initialized
+- BUG/MINOR: ssl: Double free of OCSP Certificate ID
+- MINOR: ssl/cli: Add ha_(warning|alert) msgs to CLI ckch callback
+- BUG/MINOR: ssl: Wrong OCSP CID after modifying an SSL certficate
+- BUG/MINOR: lua: Wrong OCSP CID after modifying an SSL certficate (LUA)
+- BUG/MEDIUM: proxy: always initialize the default settings after init
+
 * Wed Dec 06 2023 Anton Novojilov <andy@essentialkaos.com> - 2.8.4-0
 - BUILD: bug: make BUG_ON() void to avoid a rare warning
 - BUG/MINOR: quic: Leak of frames to send.

--- a/specs/haproxy/haproxy22.spec
+++ b/specs/haproxy/haproxy22.spec
@@ -26,7 +26,7 @@
 
 Name:           haproxy%{comp_ver}
 Summary:        TCP/HTTP reverse proxy for high availability environments
-Version:        2.2.31
+Version:        2.2.33
 Release:        0%{?dist}
 License:        GPLv2+
 URL:            https://haproxy.1wt.eu
@@ -227,6 +227,88 @@ fi
 ################################################################################
 
 %changelog
+* Tue Apr 16 2024 Anton Novojilov <andy@essentialkaos.com> - 2.2.33-0
+- DOC: configuration: typo req.ssl_hello_type
+- BUG/MEDIUM: mux-h2: Report too large HEADERS frame only when rxbuf is empty
+- BUG/MEDIUM: stconn: Forward shutdown on write timeout only if it
+  is forwardable
+- BUG/MEDIUM: spoe: Never create new spoe applet if there is no server up
+- BUG/MEDIUM: cli: some err/warn msg dumps add LR into CSV output on stat's CLI
+- BUG/MEDIUM: pool: fix rare risk of deadlock in pool_flush()
+- BUG/MINOR: h1-htx: properly initialize the err_pos field
+- BUG/MEDIUM: h1: always reject the NUL character in header values
+- BUG/MAJOR: ssl_sock: Always clear retry flags in read/write functions
+- DOC: internal: update missing data types in peers-v2.0.txt
+- CI: Update to actions/cache@v4
+- BUG/MINOR: hlua: Fix log level to the right value when set via
+  TXN:set_loglevel
+- BUG/MINOR: cfgparse: report proper location for log-format-sd errors
+- BUG/MINOR: ssl: fix possible ctx memory leak in sample_conv_aes_gcm()
+- BUG/MEDIUM: spoe: Return an invalid frame on recv if size is too small
+- BUG/MINOR: session: ensure conn owner is set after insert into session
+- BUG/MINOR: server: 'source' interface ignored from 'default-server' directive
+- BUG/MINOR: backend: properly handle redispatch 0
+- CLEANUP: pools: remove unused arguments to pool_evict_from_cache()
+- BUG/MEDIUM: spoe: Don't rely on stream's expiration to detect processing
+  timeout
+
+* Tue Apr 16 2024 Anton Novojilov <andy@essentialkaos.com> - 2.2.32-0
+- BUG/MINOR: stktable: allow sc-set-gpt(0) from tcp-request connection
+- SCRIPTS: git-show-backports: automatic ref and base detection with -m
+- DOC: lua: fix core.register_action typo
+- BUG/MEDIUM: stconn: Wake applets on sending path if there is a pending
+  shutdown
+- BUG/MEDIUM: stconn/stream: Forward shutdown on write timeout
+- BUG/MINOR: hlua/action: incorrect message on E_YIELD error
+- CI: Update to actions/checkout@v4
+- BUG/MEDIUM: hlua: don't pass stale nargs argument to lua_resume()
+- MINOR: buf: Add b_force_xfer() function
+- BUG/MEDIUM: mux-fcgi: Don't swap trash and dbuf when handling STDERR records
+- BUG/MINOR: freq_ctr: fix possible negative rate with the scaled API
+- BUG/MAJOR: mux-h2: Report a protocol error for any DATA frame before headers
+- MINOR: pattern: fix pat_{parse,match}_ip() function comments
+- BUG/MINOR: hlua: fix invalid use of lua_pop on error paths
+- BUG/MINOR: hlua_fcn: potentially unsafe stktable_data_ptr usage
+- BUILD: ssl: buggy -Werror=dangling-pointer since gcc 13.0
+- BUG/MEDIUM: actions: always apply a longest match on prefix lookup
+- BUG/MEDIUM: mux-h2: Don't report an error on shutr if a shutw is pending
+- BUG/MEDIUM: peers: Be sure to always refresh recconnect timer in sync task
+- BUG/MINOR: mux-h2: commit the current stream ID even on reject
+- BUG/MINOR: ssl: suboptimal certificate selection with TLSv1.3 and dual
+  ECDSA/RSA
+- BUG/MEDIUM: ssl: segfault when cipher is NULL
+- BUG/MINOR: tcpcheck: Report hexstring instead of binary one on check failure
+- BUG/MINOR: stktable: missing free in parse_stick_table()
+- BUG/MINOR: cfgparse/stktable: fix error message on stktable_init() failure
+- BUG/MINOR: stick-table/cli: Check for invalid ipv4 key
+- DOC: management: -q is quiet all the time
+- DOC: config: use the word 'backend' instead of 'proxy' in 'track' description
+- BUG/MINOR: stconn: Handle abortonclose if backend connection was already
+  set up
+- MINOR: connection: Add a CTL flag to notify mux it should wait for reads again
+- MEDIUM: mux-h1: Handle MUX_SUBS_RECV flag in h1_ctl() and susbscribe for reads
+- BUG/MEDIUM: stream: Properly handle abortonclose when set on backend only
+- REGTESTS: http: Improve script testing abortonclose option
+- BUG/MEDIUM: stream: Don't call mux .ctl() callback if not implemented
+- MINOR: htx: Use a macro for overhead induced by HTX
+- MINOR: channel: Add functions to get info on buffers and deal with HTX streams
+- BUG/MINOR: stconn: Fix streamer detection for HTX streams
+- BUG/MINOR: stconn: Use HTX-aware channel's functions to get info on buffer
+- BUG/MEDIUM: mux-h2: fail earlier on malloc in takeover()
+- BUG/MEDIUM: mux-h1: fail earlier on malloc in takeover()
+- BUG/MEDIUM: mux-fcgi: fail earlier on malloc in takeover()
+- REGTESTS: http: add a test to validate chunked responses delivery
+- DOC: 51d: updated 51Degrees repo URL for v3.2.10
+- DOC: config: specify supported sections for "max-session-srv-conns"
+- DOC: config: add matrix entry for "max-session-srv-conns"
+- REGTESTS: sample: Test the behavior of consecutive delimiters for the field
+  converter
+- BUG/MINOR: sample: Make the `word` converter compatible with `-m found`
+- DOC: Clarify the differences between field() and word()
+- BUG/MINOR: startup: set GTUNE_SOCKET_TRANSFER correctly
+- BUILD: ssl: work around bogus warning in gcc 12's -Wformat-truncation
+- BUG/MEDIUM: ssl: fix the gcc-12 broken fix :-(
+
 * Wed Oct 04 2023 Anton Novojilov <andy@essentialkaos.com> - 2.2.31-0
 - BUG/MINOR: server: inherit from netns in srv_settings_cpy()
 - BUG/MINOR: namespace: missing free in netns_sig_stop()

--- a/specs/haproxy/haproxy24.spec
+++ b/specs/haproxy/haproxy24.spec
@@ -17,7 +17,7 @@
 %define hp_datadir   %{_datadir}/%{orig_name}
 
 %define lua_ver       5.4.6
-%define pcre_ver      10.42
+%define pcre_ver      10.43
 %define openssl_ver   1.1.1w
 %define ncurses_ver   6.4
 %define readline_ver  8.2
@@ -27,7 +27,7 @@
 Name:           haproxy%{comp_ver}
 Summary:        TCP/HTTP reverse proxy for high availability environments
 Version:        2.4.25
-Release:        0%{?dist}
+Release:        1%{?dist}
 License:        GPLv2+
 URL:            https://haproxy.1wt.eu
 Group:          System Environment/Daemons
@@ -231,6 +231,9 @@ fi
 ################################################################################
 
 %changelog
+* Thu Mar 21 2024 Anton Novojilov <andy@essentialkaos.com> - 2.4.25-1
+- PCRE2 updated to 10.43
+
 * Wed Jan 17 2024 Anton Novojilov <andy@essentialkaos.com> - 2.4.25-0
 - BUG/MEDIUM: dns: Be sure to unlock DSS when existing dns_session_io_handler()
 - BUG/MINOR: hlua: fix invalid use of lua_pop on error paths

--- a/specs/haproxy/haproxy24.spec
+++ b/specs/haproxy/haproxy24.spec
@@ -26,8 +26,8 @@
 
 Name:           haproxy%{comp_ver}
 Summary:        TCP/HTTP reverse proxy for high availability environments
-Version:        2.4.25
-Release:        1%{?dist}
+Version:        2.4.26
+Release:        0%{?dist}
 License:        GPLv2+
 URL:            https://haproxy.1wt.eu
 Group:          System Environment/Daemons
@@ -231,6 +231,67 @@ fi
 ################################################################################
 
 %changelog
+* Tue Apr 16 2024 Anton Novojilov <andy@essentialkaos.com> - 2.4.26-0
+- BUG/MINOR: sock: mark abns sockets as non-suspendable and always unbind them
+- BUG/MEDIUM: connection: report connection errors even when no mux is installed
+- DOC: configuration: typo req.ssl_hello_type
+- BUG/MEDIUM: mux-h2: Report too large HEADERS frame only when rxbuf is empty
+- DOC: config: Update documentation about local haproxy response
+- BUG/MEDIUM: stconn: Forward shutdown on write timeout only if it is
+  forwardable
+- BUG/MEDIUM: spoe: Never create new spoe applet if there is no server up
+- BUG/MEDIUM: cli: some err/warn msg dumps add LR into CSV output on stat's CLI
+- BUG/MINOR: vars/cli: fix missing LF after "get var" output
+- BUG/MEDIUM: pool: fix rare risk of deadlock in pool_flush()
+- BUG/MINOR: h1-htx: properly initialize the err_pos field
+- BUG/MINOR: h1: Don't support LF only at the end of chunks
+- BUG/MEDIUM: h1: Don't support LF only to mark the end of a chunk size
+- BUG/MEDIUM: h1: always reject the NUL character in header values
+- BUG/MAJOR: ssl_sock: Always clear retry flags in read/write functions
+- BUG/MINOR: ssl: Clear the ckch instance when deleting a crt-list line
+- BUILD: address a few remaining calloc(size, n) cases
+- DOC: configuration: clarify http-request wait-for-body
+- DOC: install: recommend pcre2
+- DOC: internal: update missing data types in peers-v2.0.txt
+- CI: Update to actions/cache@v4
+- DEV: makefile: add a new "range" target to iteratively build all commits
+- DEV: makefile: fix POSIX compatibility for "range" target
+- BUG/MEDIUM: hlua: Don't loop if a lua socket does not consume received data
+- BUG/MINOR: ist: allocate nul byte on istdup
+- BUG/MINOR: ssl/cli: duplicate cleaning code in cli_parse_del_crtlist
+- DOC: configuration: clarify ciphersuites usage
+- BUG/MINOR: hlua: Fix log level to the right value when set via
+  TXN:set_loglevel
+- MINOR: hlua: Be able to disable logging from lua
+- BUG/MINOR: tools: seed the statistical PRNG slightly better
+- BUG/MINOR: hlua: fix unsafe lua_tostring() usage with empty stack
+- BUG/MINOR: hlua: don't use lua_tostring() from unprotected contexts
+- BUG/MEDIUM: hlua: improper lock usage with SET_SAFE_LJMP()
+- BUG/MAJOR: hlua: improper lock usage with hlua_ctx_resume()
+- BUG/MINOR: cfgparse: report proper location for log-format-sd errors
+- DOC: configuration: clarify ciphersuites usage (V2)
+- BUG/MINOR: ssl: fix possible ctx memory leak in sample_conv_aes_gcm()
+- BUG/MINOR: listener: Wake proxy's mngmt task up if necessary on session
+  release
+- BUG/MINOR: listener: Don't schedule frontend without task in
+  listener_release()
+- BUG/MEDIUM: spoe: Don't rely on stream's expiration to detect processing
+  timeout
+- BUG/MINOR: spoe: Be sure to be able to quickly close IDLE applets on soft-stop
+- CI: temporarily adjust kernel entropy to work with ASAN/clang
+- BUG/MEDIUM: spoe: Return an invalid frame on recv if size is too small
+- BUG/MINOR: session: ensure conn owner is set after insert into session
+- BUG/MEDIUM: mux-fcgi: Properly handle EOM flag on end-of-trailers HTX block
+- BUG/MINOR: server: 'source' interface ignored from 'default-server' directive
+- BUG/MINOR: server: ignore 'enabled' for dynamic servers
+- BUG/MINOR: backend: properly handle redispatch 0
+- BUG/MINOR: ist: only store NUL byte on succeeded alloc
+- DEBUG: lua: precisely identify if stream is stuck inside lua or not
+- MINOR: hlua: use accessors for stream hlua ctx
+- BUG/MEDIUM: hlua: streams don't support mixing lua-load with
+  lua-load-per-thread (2nd try)
+- BUG/MINOR: proxy: fix logformat expression leak in use_backend rules
+
 * Thu Mar 21 2024 Anton Novojilov <andy@essentialkaos.com> - 2.4.25-1
 - PCRE2 updated to 10.43
 

--- a/specs/haproxy/haproxy26.spec
+++ b/specs/haproxy/haproxy26.spec
@@ -26,8 +26,8 @@
 
 Name:           haproxy%{comp_ver}
 Summary:        TCP/HTTP reverse proxy for high availability environments
-Version:        2.6.16
-Release:        1%{?dist}
+Version:        2.6.17
+Release:        0%{?dist}
 License:        GPLv2+
 URL:            https://haproxy.1wt.eu
 Group:          System Environment/Daemons
@@ -231,6 +231,123 @@ fi
 ################################################################################
 
 %changelog
+* Tue Apr 16 2024 Anton Novojilov <andy@essentialkaos.com> - 2.6.17-0
+- BUG/MEDIUM: connection: report connection errors even when no mux is installed
+- BUG/MEDIUM: mworker: set the master variable earlier
+- BUG/MEDIUM: proxy: always initialize the default settings after init
+- DOC: configuration: typo req.ssl_hello_type
+- BUG/MINOR: mworker/cli: fix set severity-output support
+- BUG/MEDIUM: mux-h2: Report too large HEADERS frame only when rxbuf is empty
+- BUG/MINOR: resolvers: default resolvers fails when network not configured
+- DOC: config: Update documentation about local haproxy response
+- MINOR: stats: store the parent proxy in stats ctx (http)
+- BUG/MEDIUM: stats: unhandled switching rules with TCP frontend
+- MINOR: h3: check connection error during sending
+- BUG/MINOR: h3: close connection on header list too big
+- BUG/MINOR: h3: properly handle alloc failure on finalize
+- BUG/MINOR: h3: close connection on sending alloc errors
+- CLEANUP: quic: Remaining useless code into server part
+- BUG/MEDIUM: h3: fix incorrect snd_buf return value
+- BUG/MEDIUM: stconn: Forward shutdown on write timeout only if it is
+  forwardable
+- BUG/MEDIUM: spoe: Never create new spoe applet if there is no server up
+- BUG/MEDIUM: h3: fix regression which completely prevents any send
+- BUG/MINOR: mux-quic: do not prevent non-STREAM sending on flow control
+- MINOR: compiler: add a new DO_NOT_FOLD() macro to prevent code folding
+- MINOR: debug: make sure calls to ha_crash_now() are never merged
+- MINOR: debug: make ABORT_NOW() store the caller's line number when using abort
+- MINOR: debug: make BUG_ON() catch build errors even without DEBUG_STRICT
+- BUG/MEDIUM: cli: some err/warn msg dumps add LR into CSV output on stat's CLI
+- BUG/MINOR: vars/cli: fix missing LF after "get var" output
+- BUG/MINOR: jwt: fix jwt_verify crash on 32-bit archs
+- BUG/MEDIUM: pool: fix rare risk of deadlock in pool_flush()
+- BUG/MINOR: h1-htx: properly initialize the err_pos field
+- BUG/MINOR: h1: Don't support LF only at the end of chunks
+- BUG/MEDIUM: h1: Don't support LF only to mark the end of a chunk size
+- BUG/MEDIUM: h1: always reject the NUL character in header values
+- BUG/MAJOR: ssl_sock: Always clear retry flags in read/write functions
+- BUG/MINOR: ssl: Clear the ckch instance when deleting a crt-list line
+- REGTESTS: ssl: Fix empty line in cli command input
+- BUG/MINOR: h3: fix checking on NULL Tx buffer
+- CLEANUP: quic: Remove unused CUBIC_BETA_SCALE_FACTOR_SHIFT macro.
+- MINOR: quic: Stop hardcoding a scale shifting value
+  (CUBIC_BETA_SCALE_FACTOR_SHIFT)
+- MINOR: quic: extract qc_stream_buf free in a dedicated function
+- MINOR: h3: add traces for stream sending function
+- BUG/MEDIUM: h3: do not crash on invalid response status code
+- BUG/MEDIUM: qpack: allow 6xx..9xx status codes
+- BUG/MEDIUM: quic: fix crash on invalid qc_stream_buf_free() BUG_ON
+- BUG/MINOR: quic: Wrong ack ranges handling when reaching the limit.
+- CLEANUP: quic: Code clarifications for QUIC CUBIC (RFC 9438)
+- BUG/MINOR: quic: fix possible integer wrap around in cubic window calculation
+- MINOR: quic: Stop using 1024th of a second.
+- BUG/MEDIUM: quic: Wrong K CUBIC calculation.
+- MINOR: quic: Update K CUBIC calculation (RFC 9438)
+- MINOR: quic: Dynamic packet reordering threshold
+- BUG/MINOR: diag: run the final diags before quitting when using -c
+- BUILD: address a few remaining calloc(size, n) cases
+- DOC: configuration: clarify http-request wait-for-body
+- DOC: httpclient: add dedicated httpclient section
+- DOC: install: recommend pcre2
+- DOC: internal: update missing data types in peers-v2.0.txt
+- CI: Update to actions/cache@v4
+- DEV: makefile: add a new "range" target to iteratively build all commits
+- DEV: makefile: fix POSIX compatibility for "range" target
+- BUG/MAJOR: promex: fix crash on deleted server
+- BUG/MINOR: quic: reject unknown frame type
+- BUG/MINOR: quic: reject HANDSHAKE_DONE as server
+- BUG/MINOR: qpack: reject invalid increment count decoding
+- BUG/MINOR: qpack: reject invalid dynamic table capacity
+- BUG/MEDIUM: applet: Immediately free appctx on early error
+- BUG/MEDIUM: hlua: Be able to garbage collect uninitialized lua sockets
+- BUG/MEDIUM: hlua: Don't loop if a lua socket does not consume received data
+- MINOR: quic: warn on bind on multiple addresses if no IP_PKTINFO support
+- BUG/MINOR: ist: allocate nul byte on istdup
+- BUG/MINOR: stats: drop srv refcount on early release
+- BUG/MAJOR: server: fix stream crash due to deleted server
+- BUG/MINOR: ist: only store NUL byte on succeeded alloc
+- BUG/MINOR: ssl/cli: duplicate cleaning code in cli_parse_del_crtlist
+- DOC: configuration: clarify ciphersuites usage
+- BUG/MINOR: hlua: Fix log level to the right value when set via
+  TXN:set_loglevel
+- MINOR: hlua: Be able to disable logging from lua
+- BUG/MINOR: tools: seed the statistical PRNG slightly better
+- BUG/MINOR: hlua: fix unsafe lua_tostring() usage with empty stack
+- BUG/MINOR: hlua: don't use lua_tostring() from unprotected contexts
+- BUG/MINOR: hlua: fix possible crash in hlua_filter_new() under load
+- BUG/MINOR: hlua: improper lock usage in hlua_filter_callback()
+- BUG/MINOR: hlua: improper lock usage in hlua_filter_new()
+- BUG/MEDIUM: hlua: improper lock usage with SET_SAFE_LJMP()
+- BUG/MAJOR: hlua: improper lock usage with hlua_ctx_resume()
+- BUG/MINOR: ssl/cli: typo in new ssl crl-file CLI description
+- BUG/MINOR: cfgparse: report proper location for log-format-sd errors
+- DOC: configuration: clarify ciphersuites usage (V2)
+- BUG/MINOR: ssl: fix possible ctx memory leak in sample_conv_aes_gcm()
+- BUG/MINOR: hlua: segfault when loading the same filter from different contexts
+- BUG/MINOR: hlua: missing lock in hlua_filter_new()
+- BUG/MINOR: hlua: fix missing lock in hlua_filter_delete()
+- BUG/MINOR: listener: Wake proxy's mngmt task up if necessary on session
+  release
+- BUG/MINOR: listener: Don't schedule frontend without task in
+  listener_release()
+- BUG/MEDIUM: spoe: Don't rely on stream's expiration to detect processing
+  timeout
+- BUG/MINOR: spoe: Be sure to be able to quickly close IDLE applets on soft-stop
+- CI: temporarily adjust kernel entropy to work with ASAN/clang
+- BUG/MEDIUM: spoe: Return an invalid frame on recv if size is too small
+- BUG/MINOR: session: ensure conn owner is set after insert into session
+- BUG/MINOR: mux-quic: close all QCS before freeing QCC tasklet
+- BUG/MEDIUM: mux-fcgi: Properly handle EOM flag on end-of-trailers HTX block
+- BUG/MINOR: server: 'source' interface ignored from 'default-server' directive
+- BUG/MINOR: server: ignore 'enabled' for dynamic servers
+- BUG/MINOR: backend: properly handle redispatch 0
+- DOC: config: Remove httpclient.timeout.connect parameter
+- DEBUG: lua: precisely identify if stream is stuck inside lua or not
+- MINOR: hlua: use accessors for stream hlua ctx
+- BUG/MEDIUM: hlua: streams don't support mixing lua-load with
+  lua-load-per-thread (2nd try)
+- BUG/MINOR: proxy: fix logformat expression leak in use_backend rules
+
 * Thu Mar 21 2024 Anton Novojilov <andy@essentialkaos.com> - 2.6.16-1
 - OpenSSL updated to 3.0.13
 - PCRE2 updated to 10.43

--- a/specs/haproxy/haproxy26.spec
+++ b/specs/haproxy/haproxy26.spec
@@ -17,8 +17,8 @@
 %define hp_datadir   %{_datadir}/%{orig_name}
 
 %define lua_ver       5.4.6
-%define pcre_ver      10.42
-%define openssl_ver   3.0.12
+%define pcre_ver      10.43
+%define openssl_ver   3.0.13
 %define ncurses_ver   6.4
 %define readline_ver  8.2
 
@@ -27,7 +27,7 @@
 Name:           haproxy%{comp_ver}
 Summary:        TCP/HTTP reverse proxy for high availability environments
 Version:        2.6.16
-Release:        0%{?dist}
+Release:        1%{?dist}
 License:        GPLv2+
 URL:            https://haproxy.1wt.eu
 Group:          System Environment/Daemons
@@ -99,7 +99,7 @@ pushd openssl-%{openssl_ver}
   mkdir build
   # perfecto:ignore
   ./config --prefix=$(pwd)/build no-shared no-threads
-  %{__make}
+  %{__make} %{?_smp_mflags}
   %{__make} install_sw
 popd
 
@@ -231,6 +231,10 @@ fi
 ################################################################################
 
 %changelog
+* Thu Mar 21 2024 Anton Novojilov <andy@essentialkaos.com> - 2.6.16-1
+- OpenSSL updated to 3.0.13
+- PCRE2 updated to 10.43
+
 * Wed Jan 17 2024 Anton Novojilov <andy@essentialkaos.com> - 2.6.16-0
 - CI: get rid of travis-ci wrapper for Coverity scan
 - BUG/MINOR: hlua: fix invalid use of lua_pop on error paths

--- a/specs/haproxy/haproxy28.spec
+++ b/specs/haproxy/haproxy28.spec
@@ -17,8 +17,8 @@
 %define hp_datadir   %{_datadir}/%{orig_name}
 
 %define lua_ver       5.4.6
-%define pcre_ver      10.42
-%define openssl_ver   3.1.4
+%define pcre_ver      10.43
+%define openssl_ver   3.1.5
 %define ncurses_ver   6.4
 %define readline_ver  8.2
 
@@ -26,7 +26,7 @@
 
 Name:           haproxy%{comp_ver}
 Summary:        TCP/HTTP reverse proxy for high availability environments
-Version:        2.8.5
+Version:        2.8.7
 Release:        0%{?dist}
 License:        GPLv2+
 URL:            https://haproxy.1wt.eu
@@ -99,7 +99,7 @@ pushd openssl-%{openssl_ver}
   mkdir build
   # perfecto:ignore
   ./config --prefix=$(pwd)/build no-shared no-threads
-  %{__make}
+  %{__make} %{?_smp_mflags}
   %{__make} install_sw
 popd
 
@@ -231,6 +231,103 @@ fi
 ################################################################################
 
 %changelog
+* Fri Mar 22 2024 Anton Novojilov <andy@essentialkaos.com> - 2.8.7-0
+- BUG/MAJOR: ssl/ocsp: crash with ocsp when old process exit or using ocsp CLI
+
+* Thu Mar 21 2024 Anton Novojilov <andy@essentialkaos.com> - 2.8.6-0
+- DOC: configuration: typo req.ssl_hello_type
+- BUG/MINOR: mworker/cli: fix set severity-output support
+- BUG/MEDIUM: quic: Possible buffer overflow when building TLS records
+- BUG/MEDIUM: quic: QUIC CID removed from tree without locking
+- BUG/MEDIUM: mux-h2: Report too large HEADERS frame only when rxbuf is empty
+- BUG/MINOR: resolvers: default resolvers fails when network not configured
+- DOC: config: Update documentation about local haproxy response
+- MINOR: stats: store the parent proxy in stats ctx (http)
+- BUG/MEDIUM: stats: unhandled switching rules with TCP frontend
+- BUG/MINOR: mux-quic: always report error to SC on RESET_STREAM emission
+- BUG/MINOR: quic: Wrong keylog callback setting.
+- BUG/MINOR: quic: Missing call to TLS message callbacks
+- MINOR: h3: check connection error during sending
+- BUG/MINOR: h3: close connection on header list too big
+- BUG/MINOR: h3: properly handle alloc failure on finalize
+- BUG/MINOR: h3: close connection on sending alloc errors
+- CLEANUP: quic: Remaining useless code into server part
+- BUG/MEDIUM: h3: fix incorrect snd_buf return value
+- BUG/MEDIUM: stconn: Forward shutdown on write timeout only if it is
+  forwardable
+- BUG/MEDIUM: spoe: Never create new spoe applet if there is no server up
+- MINOR: mux-h2: support limiting the total number of H2 streams per connection
+- DOC: configuration: corrected description of keyword
+  tune.ssl.ocsp-update.mindelay
+- BUG/MINOR: mux-quic: do not prevent non-STREAM sending on flow control
+- BUG/MINOR: mux-h2: also count streams for refused ones
+- BUG/MEDIUM: quic: keylog callback not called (USE_OPENSSL_COMPAT)
+- MINOR: compiler: add a new DO_NOT_FOLD() macro to prevent code folding
+- MINOR: debug: make sure calls to ha_crash_now() are never merged
+- MINOR: debug: make ABORT_NOW() store the caller's line number when using abort
+- MINOR: debug: make BUG_ON() catch build errors even without DEBUG_STRICT
+- MINOR: mux-h2/traces: also suggest invalid header upon parsing error
+- MINOR: mux-h2/traces: explicitly show the error/refused stream states
+- MINOR: mux-h2/traces: clarify the "rejected H2 request" event
+- BUG/MEDIUM: mux-h2: refine connection vs stream error on headers
+- MINOR: mux-h2/traces: add a missing trace on connection WU with negative inc
+- REGTESTS: add a test to ensure map-ordering is preserved
+- BUG/MEDIUM: cli: some err/warn msg dumps add LR into CSV output on stat's CLI
+- BUG/MINOR: vars/cli: fix missing LF after "get var" output
+- BUG/MEDIUM: cli: fix once for all the problem of missing trailing LFs
+- BUG/MINOR: jwt: fix jwt_verify crash on 32-bit archs
+- BUG/MEDIUM: pool: fix rare risk of deadlock in pool_flush()
+- BUG/MEDIUM: stconn: Allow expiration update when READ/WRITE event is pending
+- BUG/MEDIUM: stconn: Don't check pending shutdown to wake an applet up
+- BUG/MINOR: h1: Don't support LF only at the end of chunks
+- BUG/MEDIUM: h1: Don't support LF only to mark the end of a chunk size
+- BUG/MINOR: h1-htx: properly initialize the err_pos field
+- BUG/MEDIUM: h1: always reject the NUL character in header values
+- BUG/MAJOR: ssl_sock: Always clear retry flags in read/write functions
+- BUG/MINOR: ssl: Fix error message after ssl_sock_load_ocsp call
+- BUG/MINOR: ssl: Duplicate ocsp update mode when dup'ing ckch
+- BUG/MINOR: ssl: Clear the ckch instance when deleting a crt-list line
+- MINOR: ssl: Use OCSP_CERTID instead of ckch_store in ckch_store_build_certid
+- BUG/MEDIUM: ocsp: Separate refcount per instance and per store
+- BUG/MINOR: ssl: Destroy ckch instances before the store during deinit
+- BUG/MINOR: ssl: Reenable ocsp auto-update after an "add ssl crt-list"
+- REGTESTS: ssl: Fix empty line in cli command input
+- REGTESTS: ssl: Add OCSP related tests
+- BUG/MEDIUM: ssl: Fix crash when calling "update ssl ocsp-response" when an
+  update is ongoing
+- BUG/MINOR: h3: fix checking on NULL Tx buffer
+- BUG/MEDIUM: mux-quic: report early error on stream
+- CLEANUP: quic: Remove unused CUBIC_BETA_SCALE_FACTOR_SHIFT macro.
+- MINOR: quic: Stop hardcoding a scale shifting value
+  (CUBIC_BETA_SCALE_FACTOR_SHIFT)
+- MINOR: quic: extract qc_stream_buf free in a dedicated function
+- BUG/MEDIUM: quic: remove unsent data from qc_stream_desc buf
+- MINOR: h3: add traces for stream sending function
+- BUG/MEDIUM: h3: do not crash on invalid response status code
+- BUG/MEDIUM: qpack: allow 6xx..9xx status codes
+- BUG/MEDIUM: quic: fix crash on invalid qc_stream_buf_free() BUG_ON
+- BUG/MINOR: quic: Wrong ack ranges handling when reaching the limit.
+- CLEANUP: quic: Code clarifications for QUIC CUBIC (RFC 9438)
+- BUG/MINOR: quic: fix possible integer wrap around in cubic window calculation
+- MINOR: quic: Stop using 1024th of a second.
+- BUG/MEDIUM: quic: Wrong K CUBIC calculation.
+- MINOR: quic: Update K CUBIC calculation (RFC 9438)
+- MINOR: quic: Dynamic packet reordering threshold
+- MINOR: quic: Add a counter for reordered packets
+- MINOR: errors: ha_alert() and ha_warning() uses warn_exec_path()
+- BUG/MINOR: diag: always show the version before dumping a diag warning
+- BUG/MINOR: diag: run the final diags before quitting when using -c
+- MINOR: ext-check: add an option to preserve environment variables
+- BUG/MINOR: ext-check: cannot use without preserve-env
+- BUILD: address a few remaining calloc(size, n) cases
+- DOC: configuration: clarify http-request wait-for-body
+- DOC: httpclient: add dedicated httpclient section
+- DOC: install: recommend pcre2
+- DOC: internal: update missing data types in peers-v2.0.txt
+- CI: Update to actions/cache@v4
+- DEV: makefile: add a new "range" target to iteratively build all commits
+- DEV: makefile: fix POSIX compatibility for "range" target
+
 * Wed Jan 17 2024 Anton Novojilov <andy@essentialkaos.com> - 2.8.5-0
 - BUG/MAJOR: quic: complete thread migration before tcp-rules
 - BUG/MEDIUM: mux-h2: fail earlier on malloc in takeover()

--- a/specs/haproxy/haproxy28.spec
+++ b/specs/haproxy/haproxy28.spec
@@ -26,7 +26,7 @@
 
 Name:           haproxy%{comp_ver}
 Summary:        TCP/HTTP reverse proxy for high availability environments
-Version:        2.8.7
+Version:        2.8.9
 Release:        0%{?dist}
 License:        GPLv2+
 URL:            https://haproxy.1wt.eu
@@ -231,6 +231,93 @@ fi
 ################################################################################
 
 %changelog
+* Tue Apr 16 2024 Anton Novojilov <andy@essentialkaos.com> - 2.8.9-0
+- BUILD: proxy: Replace free_logformat_list() to manually release log-format
+
+* Tue Apr 16 2024 Anton Novojilov <andy@essentialkaos.com> - 2.8.8-0
+- MINOR: mux-h2: add a counter of "glitches" on a connection
+- BUG/MINOR: mux-h2: count rejected DATA frames against the connection's flow
+  control
+- MINOR: mux-h2: count excess of CONTINUATION frames as a glitch
+- MINOR: mux-h2: count late reduction of INITIAL_WINDOW_SIZE as a glitch
+- MINOR: mux-h2: always use h2c_report_glitch()
+- MEDIUM: mux-h2: allow to set the glitches threshold to kill a connection
+- MINOR: connection: add a new mux_ctl to report number of connection glitches
+- MINOR: mux-h2: implement MUX_CTL_GET_GLITCHES
+- MINOR: connection: add sample fetches to report per-connection glitches
+- BUG/MAJOR: promex: fix crash on deleted server
+- BUG/MINOR: quic: reject unknown frame type
+- BUG/MINOR: quic: reject HANDSHAKE_DONE as server
+- BUG/MINOR: qpack: reject invalid increment count decoding
+- BUG/MINOR: qpack: reject invalid dynamic table capacity
+- DOC: quic: Missing tuning setting in "Global parameters"
+- BUG/MEDIUM: applet: Immediately free appctx on early error
+- BUG/MEDIUM: hlua: Be able to garbage collect uninitialized lua sockets
+- BUG/MEDIUM: hlua: Don't loop if a lua socket does not consume received data
+- BUG/MEDIUM: quic: fix transient send error with listener socket
+- DOC: quic: fix recommandation for bind on multiple address
+- MINOR: quic: warn on bind on multiple addresses if no IP_PKTINFO support
+- BUG/MINOR: ist: allocate nul byte on istdup
+- BUG/MINOR: stats: drop srv refcount on early release
+- BUG/MAJOR: server: fix stream crash due to deleted server
+- BUG/MINOR: quic: fix output of show quic
+- BUG/MINOR: ist: only store NUL byte on succeeded alloc
+- BUG/MINOR: ssl/cli: duplicate cleaning code in cli_parse_del_crtlist
+- LICENSE: event_hdl: fix GPL license version
+- LICENSE: http_ext: fix GPL license version
+- DOC: configuration: clarify ciphersuites usage
+- BUG/MINOR: config/quic: Alert about PROXY protocol use on a QUIC listener
+- BUG/MINOR: hlua: Fix log level to the right value when set via
+  TXN:set_loglevel
+- MINOR: hlua: Be able to disable logging from lua
+- BUG/MINOR: tools: seed the statistical PRNG slightly better
+- BUG/MINOR: hlua: fix unsafe lua_tostring() usage with empty stack
+- BUG/MINOR: hlua: don't use lua_tostring() from unprotected contexts
+- BUG/MINOR: hlua: fix possible crash in hlua_filter_new() under load
+- BUG/MINOR: hlua: improper lock usage in hlua_filter_callback()
+- BUG/MINOR: hlua: improper lock usage in hlua_filter_new()
+- BUG/MEDIUM: hlua: improper lock usage with SET_SAFE_LJMP()
+- BUG/MAJOR: hlua: improper lock usage with hlua_ctx_resume()
+- BUG/MINOR: hlua: don't call ha_alert() in hlua_event_subscribe()
+- BUG/MINOR: sink: fix a race condition in the TCP log forwarding code
+- CI: skip scheduled builds on forks
+- BUG/MINOR: ssl/cli: typo in new ssl crl-file CLI description
+- BUG/MINOR: cfgparse: report proper location for log-format-sd errors
+- BUILD: solaris: fix compilation errors
+- DOC: configuration: clarify ciphersuites usage (V2)
+- BUG/MINOR: ssl: fix possible ctx memory leak in sample_conv_aes_gcm()
+- BUG/MINOR: hlua: segfault when loading the same filter from different contexts
+- BUG/MINOR: hlua: missing lock in hlua_filter_new()
+- BUG/MINOR: hlua: fix missing lock in hlua_filter_delete()
+- DEBUG: lua: precisely identify if stream is stuck inside lua or not
+- MINOR: hlua: use accessors for stream hlua ctx
+- BUG/MEDIUM: hlua: streams don't support mixing lua-load with
+  lua-load-per-thread (2nd try)
+- BUG/MINOR: listener: Wake proxy's mngmt task up if necessary on session
+  release
+- BUG/MINOR: listener: Don't schedule frontend without task in
+  listener_release()
+- BUG/MEDIUM: spoe: Don't rely on stream's expiration to detect processing
+  timeout
+- BUG/MINOR: spoe: Be sure to be able to quickly close IDLE applets on soft-stop
+- CI: temporarily adjust kernel entropy to work with ASAN/clang
+- BUG/MEDIUM: spoe: Return an invalid frame on recv if size is too small
+- BUG/MINOR: session: ensure conn owner is set after insert into session
+- BUG/MEDIUM: ssl: Fix crash in ocsp-update log function
+- BUG/MINOR: mux-quic: close all QCS before freeing QCC tasklet
+- BUG/MEDIUM: mux-fcgi: Properly handle EOM flag on end-of-trailers HTX block
+- OPTIM: http_ext: avoid useless copy in http_7239_extract_{ipv4,ipv6}
+- BUG/MINOR: server: 'source' interface ignored from 'default-server' directive
+- BUG/MINOR: ssl: Wrong ocsp-update "incompatibility" error message
+- BUG/MINOR: ssl: Detect more 'ocsp-update' incompatibilities
+- BUG/MINOR: server: fix persistence cookie for dynamic servers
+- MINOR: server: allow cookie for dynamic servers
+- MINOR: cli: Remove useless loop on commands to find unescaped semi-colon
+- BUG/MEDIUM: cli: Warn if pipelined commands are delimited by a \n
+- BUG/MINOR: server: ignore 'enabled' for dynamic servers
+- BUG/MINOR: backend: properly handle redispatch 0
+- BUG/MINOR: proxy: fix logformat expression leak in use_backend rules
+
 * Fri Mar 22 2024 Anton Novojilov <andy@essentialkaos.com> - 2.8.7-0
 - BUG/MAJOR: ssl/ocsp: crash with ocsp when old process exit or using ocsp CLI
 

--- a/specs/memcached.spec
+++ b/specs/memcached.spec
@@ -11,7 +11,7 @@
 
 Summary:        High Performance, Distributed Memory Object Cache
 Name:           memcached
-Version:        1.6.23
+Version:        1.6.26
 Release:        0%{?dist}
 Group:          System Environment/Daemons
 License:        BSD
@@ -138,6 +138,15 @@ fi
 ################################################################################
 
 %changelog
+* Tue Apr 16 2024 Anton Novojilov <andy@essentialkaos.com> - 1.6.26-0
+- https://github.com/memcached/memcached/wiki/ReleaseNotes1626
+
+* Tue Apr 16 2024 Anton Novojilov <andy@essentialkaos.com> - 1.6.25-0
+- https://github.com/memcached/memcached/wiki/ReleaseNotes1625
+
+* Tue Apr 16 2024 Anton Novojilov <andy@essentialkaos.com> - 1.6.24-0
+- https://github.com/memcached/memcached/wiki/ReleaseNotes1624
+
 * Wed Jan 17 2024 Anton Novojilov <andy@essentialkaos.com> - 1.6.23-0
 - https://github.com/memcached/memcached/wiki/ReleaseNotes1623
 

--- a/specs/meson.spec
+++ b/specs/meson.spec
@@ -26,7 +26,7 @@
 
 Summary:        High productivity build system
 Name:           meson
-Version:        1.3.1
+Version:        1.4.0
 Release:        0%{?dist}
 License:        ASL 2.0
 Group:          Development/Tools
@@ -91,6 +91,9 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Tue Apr 16 2024 Anton Novojilov <andy@essentialkaos.com> - 1.4.0-0
+- https://github.com/mesonbuild/meson/compare/1.3.1...1.4.0
+
 * Wed Jan 17 2024 Anton Novojilov <andy@essentialkaos.com> - 1.3.1-0
 - https://github.com/mesonbuild/meson/compare/1.3.0...1.3.1
 

--- a/specs/nasm.spec
+++ b/specs/nasm.spec
@@ -6,7 +6,7 @@
 
 Summary:          A portable x86 assembler which uses Intel-like syntax
 Name:             nasm
-Version:          2.16.01
+Version:          2.16.02
 Release:          0%{?dist}
 License:          BSD
 Group:            Development/Languages
@@ -83,6 +83,63 @@ fi
 ################################################################################
 
 %changelog
+* Tue Apr 16 2024 Anton Novojilov <andy@essentialkaos.com> - 2.16.02-0
+- Fix building from the source distribution in a separate directory from
+  the source.
+- Fix a number of issues when building from source, mostly involving configure
+  or dependency generation.
+- In particular, more aggressively avoid cross-compilation problems on
+  Unix/Linux systems automatically invoking WINE. We could end up invoking WINE
+  even when we didn't want to, making configure think it was running native when
+  in fact cross-compiling.
+- Hopefully fix compiling with the latest versions of MSVC/nmake.
+- Windows host: add embedded manifest file. Without a manifest, Windows
+  applications force a fixed PATH_MAX limit to any pathname; this is
+  unnecessary.
+- Add support VEX-encoded SM4-NI instructions.
+- Add support for VEX-encoded SM3-NI instructions.
+- Add support for VEX-encoded SHA512-NI instructions.
+- PTWRITE opcode corrected (F3 prefix required.)
+- Disassembler: the SMAP instructions are NP; notably the prefixed versions
+  of CLAC are ERETU/ERETS.
+- Add support for Flexible Return and Exception Delivery (FRED): the LKGS,
+  ERETS and ERETU instructions.
+- Fix external references to segments in the obj (OMF) and possibly other
+  output formats.
+- Always support up to 8 characters, i.e. 64 bits, in a string-to-numeric
+  conversion.
+- Preprocessor: add %%map() function to expand a macro from a list of arguments,
+  see section 4.4.7.
+- Preprocessor: allow the user to specify the desired radix for an evaluated
+  parameter. It doesn't make any direct difference, but can be nice for
+  debugging or turning into strings. See the = modifier in section 4.2.1.
+- Update documentation: __USE_package__ is now __?USE_package?__.
+- Documentation: correct a minor problem in the expression grammar for Dx
+  statements, see section 3.2.1.
+- Preprocessor: correctly handle empty %%rep blocks.
+- Preprocessor: add options for a base prefix to %%num(), see section 4.4.8.
+- Preprocessor: add a %%hex() function, equivalent to %%eval() except that it
+  producess hexadecimal values that are nevertheless valid NASM numeric
+  constants, see section 4.4.5.
+- Preprocessor: fix the parameter number in error messages (should be 1-based,
+  like %%num references to multi-line macro arguments.)
+- Documentation: be more clear than the bin format is simply a linker built into
+  NASM. See section 8.1.
+- Adjust the LOCK prefix warning for XCHG.
+- LOCK XCHG reg,mem would issue a warning for being unlockable, which
+  is incorrect. In this case the reg,mem encoding is simply an alias for the
+  mem,reg encoding. However, XCHG is always locked, so create a new warning
+  (-w+prefix-lock-xchg) to explicitly flag a user-specified LOCK XCHG; default
+  off. Future versions of NASM may remove the LOCK prefix when optimization
+  is enabled.
+- Fix broken dependency-list generation.
+- Add optional warnings for specific relocation types (-w+reloc-*, see
+  appendix A), default off.
+- Some target environments may have specific restrictions on what kinds of
+  relocations are possible or allowed.
+- Error out on certain bad syntax in Dx statements, such as db 1 2. See
+  section 3.2.1.
+
 * Fri Oct 06 2023 Anton Novojilov <andy@essentialkaos.com> - 2.16.01-0
 - Support for the rdf format has been discontinued and all the RDOFF utilities
   has been removed.

--- a/specs/nghttp2.spec
+++ b/specs/nghttp2.spec
@@ -6,7 +6,7 @@
 
 Summary:        Meta-package that only requires libnghttp2
 Name:           nghttp2
-Version:        1.58.0
+Version:        1.61.0
 Release:        0%{?dist}
 Group:          Applications/Internet
 License:        MIT
@@ -120,6 +120,9 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Tue Apr 16 2024 Anton Novojilov <andy@essentialkaos.com> - 1.61.0-0
+- https://github.com/nghttp2/nghttp2/releases/tag/v1.61.0
+
 * Wed Dec 06 2023 Anton Novojilov <andy@essentialkaos.com> - 1.58.0-0
 - https://github.com/nghttp2/nghttp2/releases/tag/v1.58.0
 

--- a/specs/ninja-build/ninja-build.spec
+++ b/specs/ninja-build/ninja-build.spec
@@ -10,7 +10,7 @@
 
 Summary:        Small build system with a focus on speed
 Name:           ninja-build
-Version:        1.11.1
+Version:        1.12.0
 Release:        0%{?dist}
 License:        ASL 2.0
 Group:          Development/Tools
@@ -83,5 +83,8 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Tue Apr 16 2024 Anton Novojilov <andy@essentialkaos.com> - 1.12.0-0
+- https://github.com/ninja-build/ninja/milestone/6?closed=1
+
 * Fri Dec 09 2022 Anton Novojilov <andy@essentialkaos.com> - 1.11.1-0
 - Initial build

--- a/specs/nodejs.spec
+++ b/specs/nodejs.spec
@@ -16,7 +16,7 @@
 
 Summary:        Platform for server side programming on JavaScript
 Name:           nodejs
-Version:        20.11.0
+Version:        20.11.1
 Release:        0%{?dist}
 License:        MIT
 Group:          Development/Tools
@@ -106,6 +106,9 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Fri Mar 22 2024 Anton Novojilov <andy@essentialkaos.com> - 20.11.1-0
+- https://nodejs.org/en/blog/release/v20.11.1
+
 * Wed Jan 17 2024 Anton Novojilov <andy@essentialkaos.com> - 20.11.0-0
 - https://nodejs.org/en/blog/release/v20.11.0
 

--- a/specs/nodejs.spec
+++ b/specs/nodejs.spec
@@ -16,7 +16,7 @@
 
 Summary:        Platform for server side programming on JavaScript
 Name:           nodejs
-Version:        20.11.1
+Version:        20.12.2
 Release:        0%{?dist}
 License:        MIT
 Group:          Development/Tools
@@ -106,6 +106,9 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Tue Apr 16 2024 Anton Novojilov <andy@essentialkaos.com> - 20.12.2-0
+- https://nodejs.org/en/blog/release/v20.12.2
+
 * Fri Mar 22 2024 Anton Novojilov <andy@essentialkaos.com> - 20.11.1-0
 - https://nodejs.org/en/blog/release/v20.11.1
 

--- a/specs/orc.spec
+++ b/specs/orc.spec
@@ -11,7 +11,7 @@
 
 Summary:        The Oil Run-time Compiler
 Name:           orc
-Version:        0.4.34
+Version:        0.4.38
 Release:        0%{?dist}
 Group:          System Environment/Libraries
 License:        BSD
@@ -106,7 +106,6 @@ rm -rf %{buildroot}
 %{_libdir}/liborc-*.so
 %{_libdir}/pkgconfig/%{name}-0.4.pc
 %{_libdir}/pkgconfig/%{name}-test-0.4.pc
-%{_datadir}/aclocal/%{name}.m4
 
 %files compiler
 %defattr(-,root,root,-)
@@ -115,6 +114,13 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Tue Apr 16 2024 Anton Novojilov <andy@essentialkaos.com> - 0.4.38-0
+- x86: account for XSAVE when checking for AVX support, fixing usage on
+  hardened linux kernels where AVX support has been disabled
+- neon: Use the real intrinsics for divf and sqrtf
+- orc.m4 for autotools is no longer shipped. If anyone still uses
+  it they can copy it into their source tree
+
 * Wed Oct 11 2023 Anton Novojilov <andy@essentialkaos.com> - 0.4.34-0
 - Thread-safety improvements around orc codemem allocation/freeing
 - Add orc_parse_code() with more detailed error reporting

--- a/specs/rsync/rsync.spec
+++ b/specs/rsync/rsync.spec
@@ -6,7 +6,7 @@
 
 Summary:        A program for synchronizing files over a network
 Name:           rsync
-Version:        3.2.7
+Version:        3.3.0
 Release:        0%{?dist}
 License:        GPLv3+
 Group:          Applications/Internet
@@ -115,8 +115,11 @@ fi
 ################################################################################
 
 %changelog
+* Tue Apr 16 2024 Anton Novojilov <andy@essentialkaos.com> - 3.3.0-0
+- https://github.com/RsyncProject/rsync/blob/v3.3.0/NEWS.md
+
 * Sat Jul 08 2023 Anton Novojilov <andy@essentialkaos.com> - 3.2.7-0
-- https://github.com/WayneD/rsync/blob/v3.2.7/NEWS.md
+- https://github.com/RsyncProject/rsync/blob/v3.2.7/NEWS.md
 
 * Wed Feb 07 2018 Anton Novojilov <andy@essentialkaos.com> - 3.1.3-0
 - Updated to latest stable release

--- a/specs/tig.spec
+++ b/specs/tig.spec
@@ -10,7 +10,7 @@
 
 Summary:        Tig is an ncurses-based text-mode interface for git
 Name:           tig
-Version:        2.5.8
+Version:        2.5.9
 Release:        0%{?dist}
 License:        GPL
 Group:          Development/Tools
@@ -86,6 +86,9 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Tue Apr 16 2024 Anton Novojilov <andy@essentialkaos.com> - 2.5.9-0
+- https://github.com/jonas/tig/releases/tag/tig-2.5.9
+
 * Tue Apr 25 2023 Anton Novojilov <andy@essentialkaos.com> - 2.5.8-0
 - https://github.com/jonas/tig/releases/tag/tig-2.5.8
 

--- a/specs/tmux.spec
+++ b/specs/tmux.spec
@@ -6,7 +6,7 @@
 
 Summary:        A terminal multiplexer
 Name:           tmux
-Version:        3.3a
+Version:        3.4
 Release:        0%{?dist}
 License:        ISC and BSD
 Group:          Applications/System
@@ -52,9 +52,9 @@ rm -rf %{buildroot}
 
 %post
 if [[ ! -f %{_sysconfdir}/shells ]] ; then
-  echo "%{_bindir}/tmux" > %{_sysconfdir}/shells
+  echo "%{_bindir}/%{name}" > %{_sysconfdir}/shells
 else
-  grep -q "^%{_bindir}/tmux$" %{_sysconfdir}/shells || echo "%{_bindir}/tmux" >> %{_sysconfdir}/shells
+  grep -q "^%{_bindir}/%{name}$" %{_sysconfdir}/shells || echo "%{_bindir}/%{name}" >> %{_sysconfdir}/shells
 fi
 
 %clean
@@ -65,12 +65,83 @@ rm -rf %{buildroot}
 %files
 %defattr(-,root,root,-)
 %doc README README.ja CHANGES COPYING
-%{_bindir}/tmux
-%{_mandir}/man1/tmux.1.*
+%{_bindir}/%{name}
+%{_mandir}/man1/%{name}.1.*
 
 ################################################################################
 
 %changelog
+* Tue Apr 16 2024 Anton Novojilov <andy@essentialkaos.com> - 3.4-0
+- Add options keep-last and keep-group to destroy-unattached to keep the last
+  session whether in a group.
+- Don't allow paste-buffer into dead panes.
+- Add -t to source-file.
+- Rewrite combined character handling to be more consistent and to support
+  newer Unicode combined characters.
+- Add basic support for SIXEL if built with --enable-sixel.
+- Add a session, pane and user mouse range types for the status line and add
+  format variables for mouse_status_line and mouse_status_range so they can be
+  associated with different commands in the key bindings.
+- Add flag (-o) to next-prompt/previous-prompt to go to OSC 133 command output.
+- Add options and flags for menu styles (menu-style, menu-border-style) similar
+  to those existing for popups.
+- Add support for marking lines with a shell prompt based on the OSC 133
+  extension.
+- Check for libterminfo for NetBSD.
+- Add "us" to styles for underscore colour.
+- Add flags (-c and -y) to change the confirm key and default behaviour of
+  confirm-before.
+- Use ncurses' new tparm_s function (added in 6.4-20230424) instead of tparm so
+  it does not object to string arguments in c apabilities it doesn't already
+  know. Also ignore errors from tparm if using previous ncurses versions.
+- Set default lock command to vlock on Linux if present at build time.
+- Discard mouse sequences that have the right form but actually are invalid.
+- Add support for spawning panes in separate cgroups with systemd and a
+  configure flag (--disable-cgroups) to turn off.
+- Add a format (pane_unseen_changes) to show if there are unseen changes while
+  in a mode.
+- Remove old buffer when renaming rather than complaining.
+- Add an L modifier like P, W, S to loop over clients.
+- Add -f to list-clients like the other list commands.
+- Extend display-message to work for control clients.
+- Add a flag to display-menu to select the manu item selected when the menu is
+  open.
+- Have tmux recognise pasted text wrapped in bracket paste sequences, rather
+  than only forwarding them to the program inside.
+- Have client return 1 if process is interrupted to an input pane.
+- Query the client terminal for foreground and background colours and if OSC 10
+  or 11 is received but no colour has been set inside tmux, return the colour
+  from the first attached client.
+- Add send-keys -K to handle keys directly as if typed (so look up in key
+  table).
+- Process escape sequences in show-buffer.
+- Add a -l flag to display-message to disable format expansion.
+- Add paste-buffer-deleted notification and fix name of paste-buffer-changed.
+- Do not attempt to connect to the socket as a client if systemd is active.
+- Add scroll-top and scroll-bottom commands to scroll so cursor is at top or
+  bottom.
+- Add a -T flag to capture-pane to stop at the last used cell instead of the
+  full width. Restore the previous behaviour by making it default to off unless
+  -J is used.
+- Add message-line option to control where message and prompt go.
+- Notification when a when a paste buffer is deleted.
+- Add a Nobr terminfo(5) capability to tell tmux the terminal does not use
+  bright colours for bold.
+- Change g and G to go to top and bottom in menus.
+- Add a third state "all" to allow-passthrough to work even in invisible panes.
+- Add support for OSC 8 hyperlinks.
+- Store the time lines are scrolled into history and display in copy mode.
+- Add a %%config-error reply to control mode for configuration file errors since
+  reporting them in view mode is useless.
+- A new feature flag (ignorefkeys) to ignore terminfo(5) function key
+  definitions for rxvt.
+- Pass through first argument to OSC 52 (which clipboards to set) if the
+  application provides it.
+- Expand arguments to send-keys, capture-pane, split-window, join-pane where it
+  makes sense to do so.
+- Ignore named buffers when choosing a buffer if one is not specified by
+  the user.
+
 * Fri Aug 19 2022 Anton Novojilov <andy@essentialkaos.com> - 3.3a-0
 - Do not crash when run-shell produces output from a config file.
 - Do not unintentionally turn off all mouse mode when button mode is also

--- a/specs/upx.spec
+++ b/specs/upx.spec
@@ -6,7 +6,7 @@
 
 Summary:        Ultimate Packer for eXecutables
 Name:           upx
-Version:        4.2.2
+Version:        4.2.3
 Release:        0%{?dist}
 License:        GPLv2+ and Public Domain
 Group:          Applications/Archiving
@@ -73,6 +73,9 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Tue Apr 16 2024 Anton Novojilov <andy@essentialkaos.com> - 4.2.3-0
+- https://github.com/upx/upx/blob/v4.2.3/NEWS
+
 * Wed Jan 17 2024 Anton Novojilov <andy@essentialkaos.com> - 4.2.2-0
 - https://github.com/upx/upx/blob/v4.2.2/NEWS
 

--- a/specs/vips.spec
+++ b/specs/vips.spec
@@ -6,7 +6,7 @@
 
 Name:           vips
 Summary:        C/C++ library for processing large images
-Version:        8.15.1
+Version:        8.15.2
 Release:        0%{?dist}
 License:        LGPLv2+
 Group:          System Environment/Libraries
@@ -155,6 +155,9 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Tue Apr 16 2024 Anton Novojilov <andy@essentialkaos.com> - 8.15.2-0
+- https://github.com/libvips/libvips/releases/tag/v8.15.2
+
 * Wed Jan 17 2024 Anton Novojilov <andy@essentialkaos.com> - 8.15.1-0
 - https://github.com/libvips/libvips/releases/tag/v8.15.1
 

--- a/specs/yarn.spec
+++ b/specs/yarn.spec
@@ -14,7 +14,7 @@
 
 Summary:    Fast, reliable, and secure dependency management
 Name:       yarn
-Version:    1.22.21
+Version:    1.22.22
 Release:    0%{?dist}
 License:    BSD
 Group:      Development/Tools
@@ -82,6 +82,9 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Tue Apr 16 2024 Anton Novojilov <andy@essentialkaos.com> - 1.22.22-0
+- https://github.com/yarnpkg/yarn/releases/tag/v1.22.22
+
 * Thu Feb 22 2024 Anton Novojilov <andy@essentialkaos.com> - 1.22.21-0
 - https://github.com/yarnpkg/yarn/releases/tag/v1.22.21
 

--- a/specs/zstd.spec
+++ b/specs/zstd.spec
@@ -6,7 +6,7 @@
 
 Summary:        Zstandard (zstd) compression library
 Name:           zstd
-Version:        1.5.5
+Version:        1.5.6
 Release:        0%{?dist}
 License:        BSD and GPLv2
 Group:          Development/Libraries
@@ -126,6 +126,9 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Tue Apr 16 2024 Anton Novojilov <andy@essentialkaos.com> - 1.5.6-0
+- https://github.com/facebook/zstd/releases/tag/v1.5.6
+
 * Wed Apr 19 2023 Anton Novojilov <andy@essentialkaos.com> - 1.5.5-0
 - https://github.com/facebook/zstd/releases/tag/v1.5.5
 

--- a/tests/erlang/erlang24.recipe
+++ b/tests/erlang/erlang24.recipe
@@ -3,7 +3,7 @@
 
 pkg erlang24
 
-var libressl_ver 3.8.3
+var libressl_ver 3.8.4
 
 var epmd_service epmd
 var epmd_port    4369

--- a/tests/erlang/erlang24.recipe
+++ b/tests/erlang/erlang24.recipe
@@ -3,7 +3,7 @@
 
 pkg erlang24
 
-var libressl_ver 3.8.2
+var libressl_ver 3.8.3
 
 var epmd_service epmd
 var epmd_port    4369

--- a/tests/erlang/erlang25.recipe
+++ b/tests/erlang/erlang25.recipe
@@ -3,7 +3,7 @@
 
 pkg erlang25
 
-var libressl_ver 3.8.3
+var libressl_ver 3.8.4
 
 var epmd_service epmd
 var epmd_port    4369

--- a/tests/erlang/erlang25.recipe
+++ b/tests/erlang/erlang25.recipe
@@ -3,7 +3,7 @@
 
 pkg erlang25
 
-var libressl_ver 3.8.2
+var libressl_ver 3.8.3
 
 var epmd_service epmd
 var epmd_port    4369

--- a/tests/erlang/erlang26.recipe
+++ b/tests/erlang/erlang26.recipe
@@ -3,7 +3,7 @@
 
 pkg erlang26
 
-var libressl_ver 3.8.2
+var libressl_ver 3.8.3
 
 var epmd_service epmd
 var epmd_port    4369

--- a/tests/erlang/erlang26.recipe
+++ b/tests/erlang/erlang26.recipe
@@ -3,7 +3,7 @@
 
 pkg erlang26
 
-var libressl_ver 3.8.3
+var libressl_ver 3.8.4
 
 var epmd_service epmd
 var epmd_port    4369

--- a/tests/golang/golang.recipe
+++ b/tests/golang/golang.recipe
@@ -251,11 +251,6 @@ command "GOOS=openbsd GOARCH=arm64 go build -o test_openbsd_arm64 test.go" "Comp
   exist test_openbsd_arm64
   !empty test_openbsd_arm64
 
-command "GOOS=openbsd GOARCH=mips64 go build -o test_openbsd_mips64 test.go" "Compile openbsd/mips64"
-  exit 0
-  exist test_openbsd_mips64
-  !empty test_openbsd_mips64
-
 ## Plan9 #######################################################################
 
 command "GOOS=plan9 GOARCH=386 go build -o test_plan9_386 test.go" "Compile plan9/386"


### PR DESCRIPTION
### Updates

- `autoconf` updated to 2.72
- `createrepo_c` updated to 1.1.0
- `cronie` updated to 1.7.2
- `curl` updated to 8.7.1
- `elixir` updated to 1.16.2
- `erlang22` updated to 3.4.27
- `erlang23` updated to 3.4.20
- `erlang24` updated to 3.4.17
- `erlang25` updated to 3.2.11
- `erlang26` updated to 2.4
- `etcd` updated to 3.5.13
- `fish` updated to 3.7.1
- `git` updated to 2.44.0
- `goaccess` updated to 1.9.2
- `golang` updated to 1.22.2
- `gradle` updated to 8.7
- `haproxy22` updated to 2.2.33
- `haproxy24` updated to 2.4.26
- `haproxy26` updated to 2.6.17
- `haproxy28` updated to 2.8.9
- `haproxy` updated to 2.8.9
- `jdk8` updated to 1.8.0.402
- `jdk11` updated to 11.0.22
- `jdk17` updated to 17.0.10
- `jdk21` updated to 21.0.2
- `jre8` updated to 1.8.0.402
- `jre11` updated to 11.0.22
- `jre17` updated to 17.0.10
- `jre21` updated to 21.0.2
- `memcached` updated to 1.6.26
- `meson` updated to 1.4.0
- `nasm` updated to 2.16.02
- `nghttp2` updated to 1.61.0
- `ninja-build` updated to 1.12.0
- `nodejs` updated to 20.12.2
- `orc` updated to 0.4.38
- `rsync` updated to 3.3.0
- `tig` updated to 2.5.9
- `tmux` updated to 3.4
- `upx` updated to 4.2.3
- `vips` updated to 8.15.2
- `yarn` updated to 1.22.22
- `zstd` updated to 1.5.6
